### PR TITLE
Throw exception when accessing invalid property on an Expectation

### DIFF
--- a/src/Spies/Expectation.php
+++ b/src/Spies/Expectation.php
@@ -49,6 +49,7 @@ class Expectation {
 			$this->negation = true;
 			return $this;
 		}
+		throw new InvalidExpectationException( 'Invalid property: "' . $key . '" does not exist on this Expectation' );
 	}
 
 	/**

--- a/src/Spies/InvalidExpectationException.php
+++ b/src/Spies/InvalidExpectationException.php
@@ -1,0 +1,5 @@
+<?php
+namespace Spies;
+
+class InvalidExpectationException extends \Exception {
+}

--- a/tests/ExpectationTest.php
+++ b/tests/ExpectationTest.php
@@ -86,6 +86,12 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$this->assertInternalType( 'string', $expectation->verify() );
 	}
 
+	public function test_once_as_property_throws_an_error() {
+		$this->expectException( \Spies\InvalidExpectationException::class );
+		$spy = \Spies\make_spy();
+		\Spies\expect_spy( $spy )->to_have_been_called->once;
+	}
+
 	public function test_once_is_met_if_spy_is_called_once() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->once();
@@ -98,6 +104,12 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->once();
 		$expectation->silent_failures = true;
 		$this->assertInternalType( 'string', $expectation->verify() );
+	}
+
+	public function test_twice_as_property_throws_an_error() {
+		$this->expectException( \Spies\InvalidExpectationException::class );
+		$spy = \Spies\make_spy();
+		\Spies\expect_spy( $spy )->to_have_been_called->twice;
 	}
 
 	public function test_once_is_not_met_if_spy_is_called_twice() {


### PR DESCRIPTION
Throw exception when accessing invalid property on an Expectation
This should help prevent accidentally ending an Expectation with `once` instead
of `once()`.
