### PR TITLE
Refactor Expectations to use PHPUnit custom assertions

### DIFF
--- a/API.md
+++ b/API.md
@@ -113,6 +113,8 @@ These are methods available on instances of `\Spies\TestCase`.
 - `assertSpyWasNotCalledWith( $spy, $args )`
 - `assertSpyWasCalledTimes( $spy, $count )`
 - `assertSpyWasNotCalledTimes( $spy, $count )`
+- `assertSpyWasCalledTimesWith( $spy, $count, $args )`
+- `assertSpyWasNotCalledTimesWith( $spy, $count, $args )`
 - `assertSpyWasCalledBefore( $spy, $other_spy )`
 - `assertSpyWasNotCalledBefore( $spy, $other_spy )`
 - `assertSpyWasCalledWhen( $spy, $callable )`

--- a/API.md
+++ b/API.md
@@ -31,6 +31,7 @@
 - `was_called_with( $arg... )`: Return true if the Spy was called with specific arguments.
 - `was_called_when( $callable )`: Return true if the passed function returns true at least once. For each spy call, the function will be called with the arguments from that call.
 - `was_called_times( $count )`: Return true if the Spy was called exactly $count times.
+- `was_called_times_with( $count, $arg... )`: Return true if the Spy was called exactly $count times with specific arguments.
 - `was_called_before( $spy )`: Return true if the Spy was called before $spy.
 - `get_times_called()`: Return the number of times the Spy was called.
 - `get_call( $index )`: Return the call record for a single call.

--- a/src/Spies/SpiesConstraintWasCalledTimesWith.php
+++ b/src/Spies/SpiesConstraintWasCalledTimesWith.php
@@ -1,0 +1,38 @@
+<?php
+namespace Spies;
+
+class SpiesConstraintWasCalledTimesWith extends \PHPUnit_Framework_Constraint {
+	private $expected_args;
+	private $count;
+
+	public function __construct( $count, $args ) {
+		parent::__construct();
+		$this->expected_args = $args;
+		$this->count = $count;
+	}
+
+	public function matches( $other ) {
+		if ( ! $other instanceof \Spies\Spy ) {
+			return false;
+		}
+		return $other->was_called_times_with( $this->count, $this->expected_args );
+	}
+
+	protected function failureDescription( $other ) {
+		$generator = new FailureGenerator();
+		$generator->spy_was_not_called_with( $other, $this->expected_args );
+		return $generator->get_message();
+	}
+
+	protected function additionalFailureDescription( $other ) {
+		$generator = new FailureGenerator();
+		$generator->spy_was_not_called_with_additional( $other );
+		return $generator->get_message();
+	}
+
+	public function toString() {
+		return '';
+	}
+}
+
+

--- a/src/Spies/SpiesConstraintWasCalledTimesWith.php
+++ b/src/Spies/SpiesConstraintWasCalledTimesWith.php
@@ -15,7 +15,7 @@ class SpiesConstraintWasCalledTimesWith extends \PHPUnit_Framework_Constraint {
 		if ( ! $other instanceof \Spies\Spy ) {
 			return false;
 		}
-		return $other->was_called_times_with( $this->count, $this->expected_args );
+		return $other->was_called_times_with_array( $this->count, $this->expected_args );
 	}
 
 	protected function failureDescription( $other ) {

--- a/src/Spies/Spy.php
+++ b/src/Spies/Spy.php
@@ -294,15 +294,31 @@ class Spy {
 	/**
 	 * Return true if the spy was called with certain arguments a certain number of times
 	 *
+	 * Array version of was_called_with
+	 *
 	 * @param integer $times The number of times the function should have been called
 	 * @param array $arg The arguments to look for in the call record
 	 * @return boolean True if the spy was called with the arguments that number of times
 	 */
-	public function was_called_times_with( $count, $args ) {
+	public function was_called_times_with_array( $count, $args ) {
 		$matching_calls = array_filter( $this->get_called_functions(), function( $call ) use ( $args ) {
 			return ( Helpers::do_args_match( $call->get_args(), $args ) );
 		} );
 		return ( count( $matching_calls ) === $count );
+	}
+
+	/**
+	 * Return true if the spy was called with certain arguments a certain number of times
+	 *
+	 * @param integer $times The number of times the function should have been called
+	 * @param mixed $arg... The arguments to look for in the call record
+	 * @return boolean True if the spy was called with the arguments that number of times
+	 */
+	public function was_called_times_with() {
+		$all_args = func_get_args();
+		$count = $all_args[0];
+		$args = array_slice( $all_args, 1 );
+		return $this->was_called_times_with_array( $count, $args );
 	}
 
 	/**

--- a/src/Spies/Spy.php
+++ b/src/Spies/Spy.php
@@ -292,6 +292,20 @@ class Spy {
 	}
 
 	/**
+	 * Return true if the spy was called with certain arguments a certain number of times
+	 *
+	 * @param integer $times The number of times the function should have been called
+	 * @param array $arg The arguments to look for in the call record
+	 * @return boolean True if the spy was called with the arguments that number of times
+	 */
+	public function was_called_times_with( $count, $args ) {
+		$matching_calls = array_filter( $this->get_called_functions(), function( $call ) use ( $args ) {
+			return ( Helpers::do_args_match( $call->get_args(), $args ) );
+		} );
+		return ( count( $matching_calls ) === $count );
+	}
+
+	/**
 	 * Return true if a spy call causes a function to return true
 	 *
 	 * @param callable $callable A function to call with every set of arguments

--- a/src/Spies/TestCase.php
+++ b/src/Spies/TestCase.php
@@ -27,6 +27,10 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 		return new \Spies\SpiesConstraintWasCalledWhen( $callable );
 	}
 
+	public static function wasCalledTimesWith( $count, $args ) {
+		return new \Spies\SpiesConstraintWasCalledTimesWith( $count, $args );
+	}
+
 	public static function assertSpyWasCalled( $condition, $message = '' ) {
 		self::assertThat( $condition, self::wasCalled(), $message );
 	}
@@ -65,6 +69,14 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 
 	public static function assertSpyWasNotCalledWhen( $condition, $callable, $message = '' ) {
 		self::assertThat( $condition, self::logicalNot( self::wasCalledWhen( $callable ) ), $message );
+	}
+
+	public static function assertSpyWasCalledTimesWith( $condition, $count, $args, $message = '' ) {
+		self::assertThat( $condition, self::wasCalledTimesWith( $count, $args ), $message );
+	}
+
+	public static function assertSpyWasNotCalledTimesWith( $condition, $count, $args, $message = '' ) {
+		self::assertThat( $condition, self::logicalNot( self::wasCalledTimesWith( $count, $args ) ), $message );
 	}
 
 }

--- a/tests/AssertionTest.php
+++ b/tests/AssertionTest.php
@@ -52,6 +52,46 @@ class AssertionTest extends \Spies\TestCase {
 		$this->assertSpyWasNotCalledWith( $spy, [ 'a', 'b', 'c' ] );
 	}
 
+	public function test_assert_spy_was_called_times_with_is_true_when_called_that_many_times_with_args() {
+		$spy = \Spies\make_spy();
+		$spy( 'a', 'b' );
+		$spy( 'a', 'b' );
+		$spy( 'b', 'b' );
+		$this->assertSpyWasCalledTimesWith( $spy, 2, [ 'a', 'b' ] );
+	}
+
+	public function test_assert_spy_was_not_called_times_with_is_true_when_not_called_that_many_times_with_args() {
+		$spy = \Spies\make_spy();
+		$spy( 'a', 'b' );
+		$spy( 'b', 'b' );
+		$this->assertSpyWasNotCalledTimesWith( $spy, 2, [ 'a', 'b' ] );
+	}
+
+	public function test_assert_was_called_times_with_is_true_when_called_that_many_times_with_args() {
+		$spy = \Spies\make_spy();
+		$spy( 'a', 'b' );
+		$spy( 'a', 'b' );
+		$spy( 'b', 'b' );
+		$this->assertThat( $spy, $this->wasCalledTimesWith( 2, [ 'a', 'b' ] ) );
+	}
+
+	public function test_assert_was_called_times_with_is_true_when_called_more_than_that_many_times_with_args() {
+		$spy = \Spies\make_spy();
+		$spy( 'a', 'b' );
+		$spy( 'a', 'b' );
+		$spy( 'b', 'b' );
+		$this->assertThat( $spy, $this->wasCalledTimesWith( 2, [ 'a', 'b' ] ) );
+	}
+
+	public function test_assert_was_called_times_with_is_false_when_not_called_that_many_times_with_args() {
+		$spy = \Spies\make_spy();
+		$spy( 'a', 'b' );
+		$spy( 'a', 'b' );
+		$spy( 'a', 'b' );
+		$spy( 'b', 'b' );
+		$this->assertThat( $spy, $this->logicalNot( $this->wasCalledTimesWith( 2, [ 'a', 'b' ] ) ) );
+	}
+
 	public function test_assert_was_called_times_is_true_when_called_once() {
 		$spy = \Spies\make_spy();
 		$spy();

--- a/tests/ExpectationTest.php
+++ b/tests/ExpectationTest.php
@@ -17,26 +17,11 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue( $expectation instanceof \Spies\Expectation );
 	}
 
-	public function test_failure_without_not_does_not_use_not_in_the_message() {
-		$spy = \Spies\make_spy();
-		$expectation = \Spies\expect_spy( $spy )->to_have_been_called();
-		$expectation->silent_failures = true;
-		$this->assertNotContains( 'not to be called', $expectation->verify() );
-	}
-
-	public function test_failure_with_not_uses_not_in_the_message() {
-		$spy = \Spies\make_spy();
-		$spy();
-		$expectation = \Spies\expect_spy( $spy )->not->to_have_been_called();
-		$expectation->silent_failures = true;
-		$this->assertContains( 'not to be called', $expectation->verify() );
-	}
-
 	public function test_to_have_been_called_is_not_met_if_spy_was_not_called() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called();
 		$expectation->silent_failures = true;
-		$this->assertInternalType( 'string', $expectation->verify() );
+		$this->assertFalse( $expectation->verify() );
 	}
 
 	public function test_to_have_been_called_is_met_if_spy_was_called() {
@@ -73,7 +58,7 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->times( 2 );
 		$expectation->silent_failures = true;
-		$this->assertInternalType( 'string', $expectation->verify() );
+		$this->assertFalse( $expectation->verify() );
 	}
 
 	public function test_times_is_not_met_if_spy_is_called_more_than_that_many_times() {
@@ -83,7 +68,7 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$spy();
 		$spy();
 		$spy();
-		$this->assertInternalType( 'string', $expectation->verify() );
+		$this->assertFalse( $expectation->verify() );
 	}
 
 	public function test_once_as_property_throws_an_error() {
@@ -103,7 +88,7 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->once();
 		$expectation->silent_failures = true;
-		$this->assertInternalType( 'string', $expectation->verify() );
+		$this->assertFalse( $expectation->verify() );
 	}
 
 	public function test_twice_as_property_throws_an_error() {
@@ -118,7 +103,7 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$expectation->silent_failures = true;
 		$spy();
 		$spy();
-		$this->assertInternalType( 'string', $expectation->verify() );
+		$this->assertFalse( $expectation->verify() );
 	}
 
 	public function test_twice_is_met_if_spy_is_called_twice() {
@@ -133,7 +118,7 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->twice();
 		$expectation->silent_failures = true;
-		$this->assertInternalType( 'string', $expectation->verify() );
+		$this->assertFalse( $expectation->verify() );
 	}
 
 	public function test_twice_is_not_met_if_spy_is_called_thrice() {
@@ -143,7 +128,7 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$spy();
 		$spy();
 		$spy();
-		$this->assertInternalType( 'string', $expectation->verify() );
+		$this->assertFalse( $expectation->verify() );
 	}
 
 	public function test_with_is_met_if_the_spy_is_called_with_the_same_arguments() {
@@ -183,7 +168,7 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		} );
 		$expectation->silent_failures = true;
 		$spy( 'foo', 'bar' );
-		$this->assertInternalType( 'string', $expectation->verify() );
+		$this->assertFalse( $expectation->verify() );
 	}
 
 	public function test_with_is_met_if_the_spy_is_called_and_function_returns_true() {
@@ -216,7 +201,7 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		} );
 		$expectation->silent_failures = true;
 		$spy( 'foo', 'bar' );
-		$this->assertInternalType( 'string', $expectation->verify() );
+		$this->assertFalse( $expectation->verify() );
 	}
 
 	public function test_with_any_is_met_if_the_spy_is_called_with_any_arguments() {
@@ -231,7 +216,7 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', 'bar' );
 		$expectation->silent_failures = true;
 		$spy();
-		$this->assertInternalType( 'string', $expectation->verify() );
+		$this->assertFalse( $expectation->verify() );
 	}
 
 	public function test_with_is_not_met_if_the_spy_is_called_with_different_arguments() {
@@ -239,14 +224,14 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', 'bar' );
 		$expectation->silent_failures = true;
 		$spy( 'foo' );
-		$this->assertInternalType( 'string', $expectation->verify() );
+		$this->assertFalse( $expectation->verify() );
 	}
 
 	public function test_with_is_not_met_if_the_spy_is_not_called() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', 'bar' );
 		$expectation->silent_failures = true;
-		$this->assertInternalType( 'string', $expectation->verify() );
+		$this->assertFalse( $expectation->verify() );
 	}
 
 	public function test_before_is_met_if_the_spy_was_called_before_another_spy() {
@@ -265,7 +250,7 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$spy_2( 'bar' );
 		$spy_1( 'foo' );
 		$expectation->silent_failures = true;
-		$this->assertInternalType( 'string', $expectation->verify() );
+		$this->assertFalse( $expectation->verify() );
 	}
 
 	public function test_global_expectation_is_cleared_by_finish_spying() {
@@ -275,21 +260,5 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		\Spies\finish_spying();
 		$spy = \Spies\get_spy_for( 'test_func' );
 		\Spies\expect_spy( $spy )->not->to_have_been_called->with( 'first call' );
-	}
-
-	public function test_throw_exceptions_causes_spy_to_throw_exceptions_on_failure() {
-		$this->expectException( \Spies\UnmetExpectationException::class );
-		$spy = \Spies\make_spy();
-		$expectation = \Spies\expect_spy( $spy )->to_have_been_called();
-		$expectation->throw_exceptions = true;
-		$expectation->verify();
-	}
-
-	public function test_throw_exceptions_causes_spy_to_throw_exceptions_on_failure_with_finish_spying() {
-		$this->expectException( \Spies\UnmetExpectationException::class );
-		$spy = \Spies\make_spy();
-		$expectation = \Spies\expect_spy( $spy )->to_have_been_called();
-		$expectation->throw_exceptions = true;
-		\Spies\finish_spying();
 	}
 }

--- a/tests/SpyTest.php
+++ b/tests/SpyTest.php
@@ -206,13 +206,13 @@ class SpyTest extends PHPUnit_Framework_TestCase {
 		$spy( 'a', 'b' );
 		$spy( 'a', 'b' );
 		$spy( 'b', 'b' );
-		$this->assertTrue( $spy->was_called_times_with( 2, [ 'a', 'b' ] ) );
+		$this->assertTrue( $spy->was_called_times_with( 2, 'a', 'b' ) );
 	}
 
 	public function test_spy_was_called_times_with_returns_false_if_not_called_with_those_args_that_number_of_times() {
 		$spy = \Spies\make_spy();
 		$spy( 'a', 'b' );
 		$spy( 'b', 'b' );
-		$this->assertFalse( $spy->was_called_times_with( 2, [ 'a', 'b' ] ) );
+		$this->assertFalse( $spy->was_called_times_with( 2, 'a', 'b' ) );
 	}
 }

--- a/tests/SpyTest.php
+++ b/tests/SpyTest.php
@@ -200,4 +200,19 @@ class SpyTest extends PHPUnit_Framework_TestCase {
 		$spy( 'c' );
 		$this->assertEquals( ['b'], $spy->get_call( 1 )->get_args() );
 	}
+
+	public function test_spy_was_called_times_with_returns_true_if_called_with_those_args_that_number_of_times() {
+		$spy = \Spies\make_spy();
+		$spy( 'a', 'b' );
+		$spy( 'a', 'b' );
+		$spy( 'b', 'b' );
+		$this->assertTrue( $spy->was_called_times_with( 2, [ 'a', 'b' ] ) );
+	}
+
+	public function test_spy_was_called_times_with_returns_false_if_not_called_with_those_args_that_number_of_times() {
+		$spy = \Spies\make_spy();
+		$spy( 'a', 'b' );
+		$spy( 'b', 'b' );
+		$this->assertFalse( $spy->was_called_times_with( 2, [ 'a', 'b' ] ) );
+	}
 }


### PR DESCRIPTION
This will provide better error messages with the new failure message generators in the constraints.

Test:

``` php
$spy = \Spies\make_spy();
$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', 'bar' );
$spy( 'foo', 'baz' );
$expectation->verify();
```

Error Before:

```
Expected "a spy" to be called with ["foo","bar"] but instead it was called with ["foo","baz"]
Failed asserting that false is true.
```

Error After:

```
Failed asserting that a spy is called with arguments: ( "foo", "bar" ).
a spy was actually called with:
 1. arguments: ( "foo", "baz" )
```
