### PR TITLE
Update do_args_match to do casted array comparisons of objects

### DIFF
--- a/src/Spies/Helpers.php
+++ b/src/Spies/Helpers.php
@@ -15,7 +15,7 @@ class Helpers {
 			return false;
 		}
 		$index = 0;
-		foreach( $a as $arg ) {
+		foreach ( $a as $arg ) {
 			if ( ! self::do_vals_match( $arg, $b[ $index ] ) ) {
 				return false;
 			}
@@ -27,6 +27,13 @@ class Helpers {
 	private static function do_vals_match( $a, $b ) {
 		if ( $a === $b ) {
 			return true;
+		}
+		if ( is_object( $a ) || is_object( $b ) ) {
+			$array_a = is_object( $a ) ? (array) $a : $a;
+			$array_b = is_object( $b ) ? (array) $b : $b;
+			if ( $array_a === $array_b ) {
+				return true;
+			}
 		}
 		if ( $a instanceof \Spies\AnyValue || $b instanceof \Spies\AnyValue ) {
 			return true;

--- a/tests/SpyTest.php
+++ b/tests/SpyTest.php
@@ -111,6 +111,13 @@ class SpyTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue( $spy->was_called_with( 'foo', 'bar', 'baz' ) );
 	}
 
+	public function test_spy_was_called_with_returns_true_if_the_spy_was_called_with_the_object_arguments_provided() {
+		$spy = \Spies\make_spy();
+		$obj = (object) [ 'ID' => 5 ];
+		$spy( $obj );
+		$this->assertTrue( $spy->was_called_with( $obj ) );
+	}
+
 	public function test_spy_was_called_with_returns_false_if_the_spy_was_not_called_with_the_arguments_provided() {
 		$spy = \Spies\make_spy();
 		$spy( 'foo' );

--- a/tests/SpyTest.php
+++ b/tests/SpyTest.php
@@ -102,7 +102,7 @@ class SpyTest extends PHPUnit_Framework_TestCase {
 	public function test_spy_was_called_with_array_returns_false_if_the_spy_was_not_called_with_the_arguments_provided() {
 		$spy = \Spies\make_spy();
 		$spy( 'foo' );
-		$this->assertFalse( $spy->was_called_with( [ 'foo', 'bar', 'baz' ] ) );
+		$this->assertFalse( $spy->was_called_with_array( [ 'foo', 'bar', 'baz' ] ) );
 	}
 
 	public function test_spy_was_called_with_returns_true_if_the_spy_was_called_with_the_arguments_provided() {


### PR DESCRIPTION
If an object is passed as an argument to a Spy call, since v1.4.1 that object is copied before being saved for comparison. Unfortunately, this has the result that comparing the original object to its copy always returns false (since they are compared by reference and the copy is literally not the same).

This PR changes the comparison function to try comparing the objects by an array representation also.