### PR TITLE
Save SpyCall object arguments by reference

### DIFF
--- a/src/Spies/Helpers.php
+++ b/src/Spies/Helpers.php
@@ -28,28 +28,9 @@ class Helpers {
 		if ( $a === $b ) {
 			return true;
 		}
-		if ( is_object( $a ) || is_object( $b ) ) {
-			$array_a = is_object( $a ) ? (array) $a : $a;
-			$array_b = is_object( $b ) ? (array) $b : $b;
-			if ( $array_a === $array_b ) {
-				return true;
-			}
-		}
 		if ( $a instanceof \Spies\AnyValue || $b instanceof \Spies\AnyValue ) {
 			return true;
 		}
 		return false;
-	}
-
-	public static function array_clone( $array ) {
-		return array_map( function( $element ) {
-			return ( ( is_array( $element ) )
-				? Helpers::array_clone( $element )
-				: ( ( is_object( $element ) )
-				? clone $element
-				: $element
-			)
-		);
-		}, $array );
 	}
 }

--- a/src/Spies/Spy.php
+++ b/src/Spies/Spy.php
@@ -367,8 +367,7 @@ class Spy {
 	 *
 	 * You should not need to call this directly.
 	 */
-	private function record_function_call( $orig_args ) {
-		$args = Helpers::array_clone( $orig_args );
+	private function record_function_call( $args ) {
 		$this->call_record[] = new SpyCall( $args );
 	}
 

--- a/tests/SpyTest.php
+++ b/tests/SpyTest.php
@@ -118,6 +118,13 @@ class SpyTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue( $spy->was_called_with( $obj ) );
 	}
 
+	public function test_spy_was_called_with_returns_true_if_the_spy_was_called_with_the_deep_object_arguments_provided() {
+		$spy = \Spies\make_spy();
+		$obj = [ (object) [ 'ID' => 5, 'names' => [ 'bob' ], 'colors' => [ 'red' => '#f00' ] ] ];
+		$spy( [ 'foo' => $obj[0] ] );
+		$this->assertTrue( $spy->was_called_with( [ 'foo' => $obj[0] ] ) );
+	}
+
 	public function test_spy_was_called_with_returns_false_if_the_spy_was_not_called_with_the_arguments_provided() {
 		$spy = \Spies\make_spy();
 		$spy( 'foo' );
@@ -153,14 +160,24 @@ class SpyTest extends PHPUnit_Framework_TestCase {
 		} ) );
 	}
 
-	public function test_spy_was_called_when_uses_a_copy_of_the_arguments_as_they_were_when_the_call_occurred() {
+	public function test_spy_was_called_when_tests_object_arguments_by_reference() {
 		$spy = \Spies\make_spy();
 		$obj = new \StdClass();
 		$obj->foo = 'original';
 		$spy( $obj );
 		$obj->foo = 'modified';
 		$this->assertTrue( $spy->was_called_when( function( $args ) {
-			return $args[0]->foo === 'original';
+			return $args[0]->foo === 'modified';
+		} ) );
+	}
+
+	public function test_spy_was_called_when_tests_array_arguments_by_value() {
+		$spy = \Spies\make_spy();
+		$obj = [ 'foo' => 'original' ];
+		$spy( $obj );
+		$obj['foo'] = 'modified';
+		$this->assertTrue( $spy->was_called_when( function( $args ) {
+			return $args[0]['foo'] === 'original';
 		} ) );
 	}
 


### PR DESCRIPTION
Reverts changes made in [v1.4.1](92de74c) and [v1.5.1](b3ee2e2) as I think I was wrong to copy objects. Objects are passed by reference and should be treated that way by Spies. Unexpected mutations are part of the language and should be considered while writing tests.
