### PR TITLE
Add `match_array()`

### DIFF
--- a/API.md
+++ b/API.md
@@ -78,6 +78,15 @@ expect_spy( $spy )->to_have_been_called->with( any() );
 finish_spying();
 ```
 
+- `match_array()`: Used as an argument to `Expectation->with()` to mean "any argument with these values". Shortcut for `new MatchArray()`.
+
+```php
+$spy = get_spy_for( 'wp_update_post' );
+wp_update_post( [ 'title' => 'hello', 'status' => 'publish', 'id' => 14, 'post_content' => 'slartibartfast' ] );
+expect_spy( $spy )->to_have_been_called->with( match_array( [ 'status' => 'publish', 'post_content' => 'slartibartfast' ] ) );
+finish_spying();
+```
+
 - `passed_arg( $index )`: Used as an argument to `Spy->and_return()` to mean "return the passed argument at $index". Shortcut for `new PassedArgument( $index )`.
 
 ```php

--- a/README.md
+++ b/README.md
@@ -336,6 +336,23 @@ function test_calculation() {
 }
 ```
 
+You can also use `\Spies\match_array()` to match elements of an array while ignoring other parts:
+
+```php
+function tearDown() {
+	\Spies\finish_spying();
+}
+
+function test_name() {
+	$say_hello = \Spies\get_spy_for( 'say_hello' );
+
+	\Spies\expect_spy( $say_hello )->to_be_called->with( \Spies\match_array( [ 'name' => 'Raistlin' ] ) ) ); // Passes
+
+	say_hello( [ 'name' => 'Raistlin', 'job' => 'wizard', 'robes' => 'black' ] );
+}
+```
+
+
 ## PHPUnit Custom Assertions
 
 If you prefer to use PHPUnit custom assertions rather than Expectations, those are also available (although you must base your test class on `\Spies\TestCase`):

--- a/src/Spies/Helpers.php
+++ b/src/Spies/Helpers.php
@@ -31,6 +31,12 @@ class Helpers {
 		if ( $a instanceof \Spies\AnyValue || $b instanceof \Spies\AnyValue ) {
 			return true;
 		}
+		if ( $a instanceof \Spies\MatchArray && $a->is_match( $b ) ) {
+			return true;
+		}
+		if ( $b instanceof \Spies\MatchArray && $b->is_match( $a ) ) {
+			return true;
+		}
 		return false;
 	}
 }

--- a/src/Spies/MatchArray.php
+++ b/src/Spies/MatchArray.php
@@ -3,19 +3,31 @@ namespace Spies;
 
 class MatchArray {
 	public function __construct( $array ) {
-		$this->array_to_match = $array;
+		$this->expected_array = $array;
 	}
 
 	public function is_match( $actual ) {
 		if ( ! is_array( $actual ) ) {
 			return false;
 		}
-		foreach ( $this->array_to_match as $key => $value ) {
+		foreach ( $this->expected_array as $key => $value ) {
+			// Compare associative arrays
 			if ( array_key_exists( $key, $actual ) && $actual[ $key ] === $value ) {
+				return true;
+			}
+			// Compare indexed arrays
+			if ( ! $this->is_associative( $actual ) && in_array( $value, $actual ) ) {
 				return true;
 			}
 		}
 		return false;
+	}
+
+	private function is_associative( $arr ) {
+		if ( array() === $arr ) {
+			return false;
+		}
+		return array_keys( $arr ) !== range( 0, count( $arr ) - 1 );
 	}
 }
 

--- a/src/Spies/MatchArray.php
+++ b/src/Spies/MatchArray.php
@@ -10,17 +10,18 @@ class MatchArray {
 		if ( ! is_array( $actual ) ) {
 			return false;
 		}
+		$match_count = 0;
 		foreach ( $this->expected_array as $key => $value ) {
 			// Compare associative arrays
 			if ( array_key_exists( $key, $actual ) && $actual[ $key ] === $value ) {
-				return true;
+				$match_count += 1;
 			}
 			// Compare indexed arrays
 			if ( ! $this->is_associative( $actual ) && in_array( $value, $actual ) ) {
-				return true;
+				$match_count += 1;
 			}
 		}
-		return false;
+		return ( count( $this->expected_array ) === $match_count );
 	}
 
 	private function is_associative( $arr ) {

--- a/src/Spies/MatchArray.php
+++ b/src/Spies/MatchArray.php
@@ -1,0 +1,21 @@
+<?php
+namespace Spies;
+
+class MatchArray {
+	public function __construct( $array ) {
+		$this->array_to_match = $array;
+	}
+
+	public function is_match( $actual ) {
+		if ( ! is_array( $actual ) ) {
+			return false;
+		}
+		foreach ( $this->array_to_match as $key => $value ) {
+			if ( array_key_exists( $key, $actual ) && $actual[ $key ] === $value ) {
+				return true;
+			}
+		}
+		return false;
+	}
+}
+

--- a/src/Spies/functions.php
+++ b/src/Spies/functions.php
@@ -47,6 +47,10 @@ function any() {
 	return new \Spies\AnyValue();
 }
 
+function match_array( $array ) {
+	return new \Spies\MatchArray( $array );
+}
+
 function passed_arg( $index ) {
 	return new \Spies\PassedArgument( $index );
 }

--- a/tests/AssertionTest.php
+++ b/tests/AssertionTest.php
@@ -46,6 +46,18 @@ class AssertionTest extends \Spies\TestCase {
 		$this->assertSpyWasCalledWith( $spy, [ 'a', 'b', 'c' ] );
 	}
 
+	public function test_assert_that_was_called_with_is_true_when_called_with_match_array_as_argument() {
+		$spy = \Spies\make_spy();
+		$spy( [ 'foo' => 'bar', 'baz' => 'boo' ] );
+		$this->assertThat( $spy, $this->wasCalledWith( [ \Spies\match_array( [ 'foo' => 'bar' ] ) ] ) );
+	}
+
+	public function test_assert_that_was_called_with_is_true_when_called_with_match_array_and_indexed_array() {
+		$spy = \Spies\make_spy();
+		$spy( [ 'foo', 'bar', 'baz' ] );
+		$this->assertThat( $spy, $this->wasCalledWith( [ \Spies\match_array( [ 'bar' ] ) ] ) );
+	}
+
 	public function test_assert_spy_was_not_called_with_is_true_when_not_called_with_args() {
 		$spy = \Spies\make_spy();
 		$spy( 'e', 'b', 'c' );

--- a/tests/ExpectationTest.php
+++ b/tests/ExpectationTest.php
@@ -209,14 +209,14 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 
 	public function test_with_match_array_is_met_if_the_spy_is_called_with_matching_key_values() {
 		$spy = \Spies\make_spy();
-		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', \Spies\match_array( [ 'foo' => 'bar' ] ) );
+		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', \Spies\match_array( [ 'foo' => 'bar', 'flim' => 'flam' ] ) );
 		$spy( 'foo', [ 'bar' => 'baz', 'foo' => 'bar', 'flim' => 'flam' ] );
 		$expectation->verify();
 	}
 
 	public function test_with_match_array_is_met_if_the_spy_is_called_with_matching_index_keys() {
 		$spy = \Spies\make_spy();
-		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', \Spies\match_array( [ 'bar' ] ) );
+		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', \Spies\match_array( [ 'bar', 'foo' ] ) );
 		$spy( 'foo', [ 'foo', 'bar', 'baz' ] );
 		$expectation->verify();
 	}
@@ -232,6 +232,14 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 	public function test_with_match_array_is_not_met_if_the_spy_is_called_with_no_matching_key_values() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', \Spies\match_array( [ 'foo' => 'baz' ] ) );
+		$expectation->silent_failures = true;
+		$spy( 'foo', [ 'bar' => 'baz', 'foo' => 'bar', 'flim' => 'flam' ] );
+		$this->assertFalse( $expectation->verify() );
+	}
+
+	public function test_with_match_array_is_not_met_if_the_spy_is_called_with_some_matching_key_values() {
+		$spy = \Spies\make_spy();
+		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', \Spies\match_array( [ 'foo' => 'baz', 'flim' => 'flam' ] ) );
 		$expectation->silent_failures = true;
 		$spy( 'foo', [ 'bar' => 'baz', 'foo' => 'bar', 'flim' => 'flam' ] );
 		$this->assertFalse( $expectation->verify() );

--- a/tests/ExpectationTest.php
+++ b/tests/ExpectationTest.php
@@ -214,6 +214,21 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$expectation->verify();
 	}
 
+	public function test_with_match_array_is_met_if_the_spy_is_called_with_matching_index_keys() {
+		$spy = \Spies\make_spy();
+		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', \Spies\match_array( [ 'bar' ] ) );
+		$spy( 'foo', [ 'foo', 'bar', 'baz' ] );
+		$expectation->verify();
+	}
+
+	public function test_with_match_array_is_not_met_if_the_spy_is_called_with_no_matching_index_keys() {
+		$spy = \Spies\make_spy();
+		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', \Spies\match_array( [ 'beep' ] ) );
+		$expectation->silent_failures = true;
+		$spy( 'foo', [ 'foo', 'bar', 'baz' ] );
+		$this->assertFalse( $expectation->verify() );
+	}
+
 	public function test_with_match_array_is_not_met_if_the_spy_is_called_with_no_matching_key_values() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', \Spies\match_array( [ 'foo' => 'baz' ] ) );

--- a/tests/ExpectationTest.php
+++ b/tests/ExpectationTest.php
@@ -207,6 +207,21 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse( $expectation->verify() );
 	}
 
+	public function test_with_match_array_is_met_if_the_spy_is_called_with_matching_key_values() {
+		$spy = \Spies\make_spy();
+		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', \Spies\match_array( [ 'foo' => 'bar' ] ) );
+		$spy( 'foo', [ 'bar' => 'baz', 'foo' => 'bar', 'flim' => 'flam' ] );
+		$expectation->verify();
+	}
+
+	public function test_with_match_array_is_not_met_if_the_spy_is_called_with_no_matching_key_values() {
+		$spy = \Spies\make_spy();
+		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', \Spies\match_array( [ 'foo' => 'baz' ] ) );
+		$expectation->silent_failures = true;
+		$spy( 'foo', [ 'bar' => 'baz', 'foo' => 'bar', 'flim' => 'flam' ] );
+		$this->assertFalse( $expectation->verify() );
+	}
+
 	public function test_with_any_is_met_if_the_spy_is_called_with_any_arguments() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', \Spies\any() );


### PR DESCRIPTION
Allow matching parts of arrays rather than having to match the whole array.

```
$spy = get_spy_for( 'wp_update_post' );
wp_update_post( [ 'title' => 'hello', 'status' => 'publish', 'id' => 14, 'post_content' => 'slartibartfast' ] );
expect_spy( $spy )->to_have_been_called->with( match_array( [ 'status' => 'publish', 'post_content' => 'slartibartfast' ] ) );
finish_spying();
```
