### PR TITLE
Add match_pattern

### DIFF
--- a/API.md
+++ b/API.md
@@ -78,6 +78,21 @@ expect_spy( $spy )->to_have_been_called->with( any() );
 finish_spying();
 ```
 
+- `match_pattern()`: Used as an argument to `Expectation->with()` or `Spy()->with()` to mean "any string argument matching this PCRE pattern". Shortcut for `new MatchPattern()`.
+
+```php
+$spy = get_spy_for( 'run_experiment' );
+run_experiment( 'slartibartfast' );
+expect_spy( $spy )->to_have_been_called->with( match_pattern( '/bart/' ) );
+finish_spying();
+```
+
+```php
+mock_function( 'slartibartfast' )->when_called->with( match_pattern( '/bart/' ) )->will_return( 14 );
+$id = run_experiment( 'slartibartfast' );
+$this->assertEquals( 14, $id );
+```
+
 - `match_array()`: Used as an argument to `Expectation->with()` or `Spy()->with()` to mean "any argument with these values". Shortcut for `new MatchArray()`.
 
 ```php

--- a/README.md
+++ b/README.md
@@ -336,6 +336,15 @@ function test_calculation() {
 }
 ```
 
+If you need to match just part of a string, you can use `\Spies\match_pattern()`.
+
+```php
+$spy = \Spies\get_spy_for( 'run_experiment' );
+run_experiment( 'slartibartfast' );
+\Spies\expect_spy( $spy )->to_have_been_called->with( \Spies\match_pattern( '/bart/' ) );
+\Spies\finish_spying();
+```
+
 You can also use `\Spies\match_array()` to match elements of an array while ignoring other parts:
 
 ```php

--- a/src/Spies/Helpers.php
+++ b/src/Spies/Helpers.php
@@ -31,6 +31,12 @@ class Helpers {
 		if ( $a instanceof \Spies\AnyValue || $b instanceof \Spies\AnyValue ) {
 			return true;
 		}
+		if ( $a instanceof \Spies\MatchPattern && $a->is_match( $b ) ) {
+			return true;
+		}
+		if ( $b instanceof \Spies\MatchPattern && $b->is_match( $a ) ) {
+			return true;
+		}
 		if ( $a instanceof \Spies\MatchArray && $a->is_match( $b ) ) {
 			return true;
 		}

--- a/src/Spies/MatchPattern.php
+++ b/src/Spies/MatchPattern.php
@@ -1,0 +1,21 @@
+<?php
+namespace Spies;
+
+class MatchPattern {
+	public function __construct( $pattern ) {
+		$this->expected_pattern = $pattern;
+	}
+
+	public function is_match( $actual ) {
+		if ( ! is_string( $actual ) ) {
+			return false;
+		}
+		// Convert 0 and FALSE to false and 1 to true
+		if ( preg_match( $this->expected_pattern, $actual ) ) {
+			return true;
+		}
+		return false;
+	}
+}
+
+

--- a/src/Spies/functions.php
+++ b/src/Spies/functions.php
@@ -51,6 +51,10 @@ function match_array( $array ) {
 	return new \Spies\MatchArray( $array );
 }
 
+function match_pattern( $pattern ) {
+	return new \Spies\MatchPattern( $pattern );
+}
+
 function passed_arg( $index ) {
 	return new \Spies\PassedArgument( $index );
 }

--- a/tests/AssertionTest.php
+++ b/tests/AssertionTest.php
@@ -46,6 +46,18 @@ class AssertionTest extends \Spies\TestCase {
 		$this->assertSpyWasCalledWith( $spy, [ 'a', 'b', 'c' ] );
 	}
 
+	public function test_assert_that_was_called_with_is_true_when_called_with_match_pattern_as_argument() {
+		$spy = \Spies\make_spy();
+		$spy( 'slartibartfast' );
+		$this->assertThat( $spy, $this->wasCalledWith( [ \Spies\match_pattern( '/Bart/i' ) ] ) );
+	}
+
+	public function test_assert_that_was_called_with_is_false_when_called_with_match_pattern_as_argument() {
+		$spy = \Spies\make_spy();
+		$spy( 'bar' );
+		$this->assertThat( $spy, $this->logicalNot( $this->wasCalledWith( [ \Spies\match_pattern( '/Bart/i' ) ] ) ) );
+	}
+
 	public function test_assert_that_was_called_with_is_true_when_called_with_match_array_as_argument() {
 		$spy = \Spies\make_spy();
 		$spy( [ 'foo' => 'bar', 'baz' => 'boo' ] );

--- a/tests/ExpectationTest.php
+++ b/tests/ExpectationTest.php
@@ -207,6 +207,21 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse( $expectation->verify() );
 	}
 
+	public function test_with_match_pattern_is_met_if_the_spy_is_called_with_matching_pattern() {
+		$spy = \Spies\make_spy();
+		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', \Spies\match_pattern( '/Bart/i' ) );
+		$spy( 'foo', 'slartibartfast' );
+		$expectation->verify();
+	}
+
+	public function test_with_match_pattern_is_not_met_if_the_spy_is_called_with_differing_pattern() {
+		$spy = \Spies\make_spy();
+		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', \Spies\match_pattern( '/Bart/i' ) );
+		$expectation->silent_failures = true;
+		$spy( 'foo', 'slartiblargfast' );
+		$this->assertFalse( $expectation->verify() );
+	}
+
 	public function test_with_match_array_is_met_if_the_spy_is_called_with_matching_key_values() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', \Spies\match_array( [ 'foo' => 'bar', 'flim' => 'flam' ] ) );

--- a/tests/StubTest.php
+++ b/tests/StubTest.php
@@ -61,6 +61,15 @@ class StubTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 6, test_stub( 'bar' ) );
 	}
 
+	public function test_stub_when_called_with_match_pattern_sets_a_conditional_return_value_on_the_stub() {
+		\Spies\mock_function( 'test_stub' )->will_return( 4 );
+		\Spies\mock_function( 'test_stub' )->when_called->with( \Spies\match_pattern( '/boko/i' ) )->will_return( 5 );
+		\Spies\mock_function( 'test_stub' )->when_called->with( \Spies\match_pattern( '/mob/i' ) )->will_return( 6 );
+		$this->assertEquals( 5, test_stub( 'Bokoblin' ) );
+		$this->assertEquals( 6, test_stub( 'Moblin' ) );
+		$this->assertEquals( 4, test_stub( 'Lizafos' ) );
+	}
+
 	public function test_stub_when_called_with_match_array_sets_a_conditional_return_value_on_the_stub() {
 		\Spies\mock_function( 'test_stub' )->will_return( 4 );
 		\Spies\mock_function( 'test_stub' )->when_called->with( \Spies\match_array( [ 'type' => 'Bokoblin' ] ) )->will_return( 5 );


### PR DESCRIPTION
Add `match_pattern()` which operates like `match_array()`, but allows matching a string with a [PCRE](http://php.net/manual/en/book.pcre.php).