### PR TITLE
Allow MockObject to have a delegate instance

### DIFF
--- a/API.md
+++ b/API.md
@@ -63,7 +63,7 @@ $obj->run();
 ```
 
 ```php
-$obj = \Spies\mock_object( new Greeter() );
+$mock = \Spies\mock_object( new Greeter() );
 $say_goodbye = $mock->spy_on_method( 'say_goodbye' );
 $mock->add_method( 'say_hello' )->that_returns( 'greetings' );
 $this->assertEquals( 'greetings', $mock->say_hello() );

--- a/API.md
+++ b/API.md
@@ -53,12 +53,22 @@ $expectation->verify();
 
 ### `mock_object()`
 
-Shortcut for `MockObject::mock_object()`.
+Shortcut for `MockObject::mock_object()`. Can also be used to create a
+mock object with a delegate.
 
 ```php
 $obj = mock_object();
 $obj->add_method( 'run' );
 $obj->run();
+```
+
+```php
+$obj = \Spies\mock_object( new Greeter() );
+$say_goodbye = $mock->spy_on_method( 'say_goodbye' );
+$mock->add_method( 'say_hello' )->that_returns( 'greetings' );
+$this->assertEquals( 'greetings', $mock->say_hello() );
+$this->assertEquals( 'goodbye', $mock->say_goodbye() );
+$this->assertSpyWasCalled( $say_goodbye );
 ```
 
 ### `mock_object_of( $class_name )`
@@ -433,12 +443,37 @@ $this->assertGreaterThan( $now, $calls[0]->get_timestamp() );
 
 ### `mock_object()`
 
-Shortcut for `new MockObject()`.
+Shortcut for `new MockObject()`. If a class instance is passed as an
+argument, it creates a delegate instance, forwarding all method calls on
+the MockObject to the delegate instance.
 
 ```php
 $obj = Spies\MockObject::mock_object();
 $obj->add_method( 'run' );
 $obj->run();
+```
+
+Using a delegate:
+
+```php
+class Greeter {
+	public function say_hello() {
+		return 'hello';
+	}
+
+	public function say_goodbye() {
+		return 'goodbye';
+	}
+}
+
+function test_greeter() {
+	$mock = Spies\MockObject::mock_object( new Greeter() );
+	$say_goodbye = $mock->spy_on_method( 'say_goodbye' );
+	$mock->add_method( 'say_hello' )->that_returns( 'greetings' );
+	$this->assertEquals( 'greetings', $mock->say_hello() );
+	$this->assertEquals( 'goodbye', $mock->say_goodbye() );
+	$this->assertSpyWasCalled( $say_goodbye );
+}
 ```
 
 ### `mock_object_of( $class_name )`

--- a/API.md
+++ b/API.md
@@ -1,29 +1,37 @@
 # Spies API Reference
 
-# functions
+## functions
 
-- `make_spy()`: Shortcut for `new Spy()`.
+### `make_spy()`
+
+Shortcut for `new Spy()`.
 
 ```php
 $spy = make_spy();
 $spy();
 ```
 
-- `get_spy_for( $function_name )`: Spy on a global or namespaced function. Shortcut for `Spy::stub_function( $function_name )`.
+### `get_spy_for( $function_name )`
+
+Spy on a global or namespaced function. Shortcut for `Spy::stub_function( $function_name )`.
 
 ```php
 $spy = get_spy_for( 'wp_update_post' );
 wp_update_post();
 ```
 
-- `stub_function( $function_name )`: Stub a global or namespaced function. Shortcut for `Spy::stub_function( $function_name )`.
+### `stub_function( $function_name )`
+
+Stub a global or namespaced function. Shortcut for `Spy::stub_function( $function_name )`.
 
 ```php
 stub_function( 'wp_update_post' );
 wp_update_post();
 ```
 
-- `mock_function( $function_name )`: Alias for `stub_function()`.
+### `mock_function( $function_name )`
+
+Alias for `stub_function()`.
 
 
 ```php
@@ -31,7 +39,9 @@ mock_function( 'wp_update_post' );
 wp_update_post();
 ```
 
-- `expect_spy( $spy )`: Shortcut for `Expectation::expect_spy( $spy )`.
+### `expect_spy( $spy )`
+
+Shortcut for `Expectation::expect_spy( $spy )`.
 
 
 ```php
@@ -41,7 +51,9 @@ $expectation = expect_spy( $spy )->to_have_been_called();
 $expectation->verify();
 ```
 
-- `mock_object()`: Shortcut for `MockObject::mock_object()`.
+### `mock_object()`
+
+Shortcut for `MockObject::mock_object()`.
 
 ```php
 $obj = mock_object();
@@ -49,7 +61,9 @@ $obj->add_method( 'run' );
 $obj->run();
 ```
 
-- `mock_object_of( $class_name )`: Mock an instance of an existing class with all its methods. Shortcut for `MockObject::mock_object( $class_name )`.
+### `mock_object_of( $class_name )`
+
+Mock an instance of an existing class with all its methods. Shortcut for `MockObject::mock_object( $class_name )`.
 
 ```php
 class TestObj {
@@ -60,7 +74,9 @@ $obj = mock_object_of( 'TestObj' );
 $obj->run();
 ```
 
-- `finish_spying()`: Resolve all global Expectations, then clear all Expectations and all global Spies. Shortcut for `GlobalExpectations::resolve_delayed_expectations()`, `GlobalExpectations::clear_all_expectations()`, and `GlobalSpies::clear_all_spies`.
+### `finish_spying()`
+
+Resolve all global Expectations, then clear all Expectations and all global Spies. Shortcut for `GlobalExpectations::resolve_delayed_expectations()`, `GlobalExpectations::clear_all_expectations()`, and `GlobalSpies::clear_all_spies`.
 
 ```php
 $spy = get_spy_for( 'wp_update_post' );
@@ -69,7 +85,9 @@ expect_spy( $spy )->to_have_been_called();
 finish_spying();
 ```
 
-- `any()`: Used as an argument to `Expectation->with()` to mean "any argument". Shortcut for `new AnyValue()`.
+### `any()`
+
+Used as an argument to `Expectation->with()` to mean "any argument". Shortcut for `new AnyValue()`.
 
 ```php
 $spy = get_spy_for( 'wp_update_post' );
@@ -78,7 +96,9 @@ expect_spy( $spy )->to_have_been_called->with( any() );
 finish_spying();
 ```
 
-- `match_pattern()`: Used as an argument to `Expectation->with()` or `Spy()->with()` to mean "any string argument matching this PCRE pattern". Shortcut for `new MatchPattern()`.
+### `match_pattern()`
+
+Used as an argument to `Expectation->with()` or `Spy()->with()` to mean "any string argument matching this PCRE pattern". Shortcut for `new MatchPattern()`.
 
 ```php
 $spy = get_spy_for( 'run_experiment' );
@@ -93,7 +113,9 @@ $id = run_experiment( 'slartibartfast' );
 $this->assertEquals( 14, $id );
 ```
 
-- `match_array()`: Used as an argument to `Expectation->with()` or `Spy()->with()` to mean "any argument with these values". Shortcut for `new MatchArray()`.
+### `match_array()`
+
+Used as an argument to `Expectation->with()` or `Spy()->with()` to mean "any argument with these values". Shortcut for `new MatchArray()`.
 
 ```php
 $spy = get_spy_for( 'wp_update_post' );
@@ -108,7 +130,9 @@ $id = wp_update_post( [ 'title' => 'hello', 'status' => 'publish', 'post_content
 $this->assertEquals( 14, $id );
 ```
 
-- `passed_arg( $index )`: Used as an argument to `Spy->and_return()` to mean "return the passed argument at $index". Shortcut for `new PassedArgument( $index )`.
+### `passed_arg( $index )`
+
+Used as an argument to `Spy->and_return()` to mean "return the passed argument at $index". Shortcut for `new PassedArgument( $index )`.
 
 ```php
 stub_function( 'wp_update_post' )->and_return( passed_arg( 1 ) );
@@ -116,18 +140,22 @@ $value = wp_update_post( 'hello' );
 $this->assertEquals( 'hello', $value );
 ```
 
-- `do_arrays_match( $a, $b )`: Compare two arrays allowing usage of `match_array()`.
+### `do_arrays_match( $a, $b )`
+
+Compare two arrays allowing usage of `match_array()`.
 
 ```php
 $array = [ 'baz' => 'boo', 'foo' => 'bar' ];
 $this->assertTrue( \Spies\do_arrays_match( $array, \Spies\match_array( [ 'foo' => 'bar' ] ) ) );
 ```
 
-# Spy
+## Spy
 
 ### Static methods
 
-- `get_spy_for( $function_name )`: Create a new global or namespaced function and attach it to a new Spy, returning that Spy.
+### `get_spy_for( $function_name )`
+
+Create a new global or namespaced function and attach it to a new Spy, returning that Spy.
 
 ```php
 $spy = Spy::get_spy_for( 'wp_update_post' );
@@ -138,7 +166,9 @@ finish_spying();
 
 ### Instance methods
 
-- `get_function_name()`: Return the spy's function name. Really only useful when spying on global or namespaced functions. Defaults to "a spy".
+### `get_function_name()`
+
+Return the spy's function name. Really only useful when spying on global or namespaced functions. Defaults to "a spy".
 
 ```php
 $spy = get_spy_for( 'wp_update_post' );
@@ -147,7 +177,9 @@ $spy2 = make_spy();
 $this->assertEquals( 'a spy', $spy2->get_function_name() );
 ```
 
-- `set_function_name()`: Set the spy's function name. You generally don't need to use this.
+### `set_function_name()`
+
+Set the spy's function name. You generally don't need to use this.
 
 ```php
 $spy = make_spy();
@@ -155,7 +187,9 @@ $spy->set_function_name( 'foo' );
 $this->assertEquals( 'foo', $spy->get_function_name() );
 ```
 
-- `call( $arg... )`: Call the Spy. It's probably easier to just call the Spy as a function like this: `$spy()`.
+### `call( $arg... )`
+
+Call the Spy. It's probably easier to just call the Spy as a function like this: `$spy()`.
 
 ```php
 $spy = make_spy();
@@ -163,7 +197,9 @@ $spy->call( 1, 2, 3 );
 $this->assertSpyWasCalledWith( $spy, [ 1, 2, 3 ] );
 ```
 
-- `call_with_array( $args )`: Call the Spy with an array of arguments. It's probably easier to just call the Spy as a function.
+### `call_with_array( $args )`
+
+Call the Spy with an array of arguments. It's probably easier to just call the Spy as a function.
 
 ```php
 $spy = make_spy();
@@ -171,7 +207,9 @@ $spy->call_with_array( [ 1, 2, 3 ] );
 $this->assertSpyWasCalledWith( $spy, [ 1, 2, 3 ] );
 ```
 
-- `clear_call_record()`: Clear the Spy's call record. You shouldn't need to call this.
+### `clear_call_record()`
+
+Clear the Spy's call record. You shouldn't need to call this.
 
 ```php
 $spy = make_spy();
@@ -180,7 +218,9 @@ $spy->clear_call_record();
 $this->assertSpyWasNotCalled( $spy );
 ```
 
-- `get_called_functions()`: Get the raw call record for the Spy. Each call is an instance of `SpyCall`.
+### `get_called_functions()`
+
+Get the raw call record for the Spy. Each call is an instance of `SpyCall`.
 
 ```php
 $spy = make_spy();
@@ -189,7 +229,9 @@ $calls = $spy->get_called_functions();
 $this->assertEquals( [ 1, 2, 3 ], $calls[0]->get_args() );
 ```
 
-- `was_called()`: Return true if the Spy was called.
+### `was_called()`
+
+Return true if the Spy was called.
 
 ```php
 $spy = make_spy();
@@ -197,7 +239,9 @@ $spy();
 $this->assertTrue( $spy->was_called() );
 ```
 
-- `was_called_with( $arg... )`: Return true if the Spy was called with specific arguments.
+### `was_called_with( $arg... )`
+
+Return true if the Spy was called with specific arguments.
 
 ```php
 $spy = make_spy();
@@ -205,7 +249,9 @@ $spy( 'a', 'b' );
 $this->assertTrue( $spy->was_called_with( 'a', 'b' ) );
 ```
 
-- `was_called_when( $callable )`: Return true if the passed function returns true at least once. For each spy call, the function will be called with the arguments from that call as an array.
+### `was_called_when( $callable )`
+
+Return true if the passed function returns true at least once. For each spy call, the function will be called with the arguments from that call as an array.
 
 ```php
 $spy = make_spy();
@@ -215,7 +261,9 @@ $this->assertTrue( $spy->was_called_when( function( $args ) {
 } ) );
 ```
 
-- `was_called_times( $count )`: Return true if the Spy was called exactly `$count` times.
+### `was_called_times( $count )`
+
+Return true if the Spy was called exactly `$count` times.
 
 ```php
 $spy = make_spy();
@@ -224,7 +272,9 @@ $spy();
 $this->assertTrue( $spy->was_called_times( 2 ) );
 ```
 
-- `was_called_times_with( $count, $arg... )`: Return true if the Spy was called exactly $count times with specific arguments.
+### `was_called_times_with( $count, $arg... )`
+
+Return true if the Spy was called exactly $count times with specific arguments.
 
 ```php
 $spy = make_spy();
@@ -234,7 +284,9 @@ $spy( 'c', 'd' );
 $this->assertTrue( $spy->was_called_times_with( 2, 'a', 'b' ) );
 ```
 
-- `was_called_before( $spy )`: Return true if the Spy was called before $spy.
+### `was_called_before( $spy )`
+
+Return true if the Spy was called before $spy.
 
 ```php
 $spy = make_spy();
@@ -244,7 +296,9 @@ $spy2();
 $this->assertTrue( $spy->was_called_before( $spy2 ) );
 ```
 
-- `get_times_called()`: Return the number of times the Spy was called.
+### `get_times_called()`
+
+Return the number of times the Spy was called.
 
 ```php
 $spy = make_spy();
@@ -253,7 +307,9 @@ $spy();
 $this->assertEquals( 2, $spy->get_times_called() );
 ```
 
-- `get_call( $index )`: Return the call record for a single call.
+### `get_call( $index )`
+
+Return the call record for a single call.
 
 ```php
 $spy = make_spy();
@@ -263,11 +319,13 @@ $call = $spy->get_call( 0 );
 $this->assertEquals( [ 'a' ], $call->get_args() );
 ```
 
-# Stub (Stubs are actually just instances of Spy used differently)
+## Stub (Stubs are actually just instances of Spy used differently)
 
 ### Static methods
 
-- `stub_function( $function_name )`: Create a new global or namespaced function and attach it to a new Spy, returning that Spy.
+### `stub_function( $function_name )`
+
+Create a new global or namespaced function and attach it to a new Spy, returning that Spy.
 
 ```php
 Spy::stub_function( 'say_hello' )->and_return( 'hello' );
@@ -276,21 +334,27 @@ $this->assertEquals( 'hello', say_hello() );
 
 ### Instance methods
 
-- `and_return( $value )`: Instruct the stub to return $value when called. $value can also be a function to call when the stub is called.
+### `and_return( $value )`
+
+Instruct the stub to return $value when called. $value can also be a function to call when the stub is called.
 
 ```php
 Spy::stub_function( 'say_hello' )->and_return( 'hello' );
 $this->assertEquals( 'hello', say_hello() );
 ```
 
-- `will_return( $value )`: Alias for `and_return( $value )`.
+### `will_return( $value )`
+
+Alias for `and_return( $value )`.
 
 ```php
 Spy::stub_function( 'say_hello' )->when_called->will_return( 'hello' );
 $this->assertEquals( 'hello', say_hello() );
 ```
 
-- `that_returns( $value )`: Alias for `and_return( $value )`.
+### `that_returns( $value )`
+
+Alias for `and_return( $value )`.
 
 ```php
 $obj = mock_object();
@@ -298,7 +362,9 @@ $obj->add_method( 'run' )->that_returns( 'hello' );
 $this->assertEquals( 'hello', $obj->say_hello() );
 ```
 
-- `with( $arg... )`: Changes behavior of next `and_return()` to be a conditional return value.
+### `with( $arg... )`
+
+Changes behavior of next `and_return()` to be a conditional return value.
 
 ```php
 Spy::stub_function( 'say_hello' )->when_called->will_return( 'beep' );
@@ -307,32 +373,40 @@ $this->assertEquals( 'hello', say_hello( 'human' ) );
 $this->assertEquals( 'beep', say_hello( 'robot' ) );
 ```
 
-- `when_called`: Syntactic sugar. Returns the Stub.
+### `when_called`
+
+Syntactic sugar. Returns the Stub.
 
 ```php
 Spy::stub_function( 'say_hello' )->when_called->will_return( 'hello' );
 $this->assertEquals( 'hello', say_hello() );
 ```
 
-- `and_return_first_argument()`: Shortcut for `and_return( passed_arg( 0 ) )`.
+### `and_return_first_argument()`
+
+Shortcut for `and_return( passed_arg( 0 ) )`.
 
 ```php
 Spy::stub_function( 'say_hello' )->and_return_first_argument();
 $this->assertEquals( 'hi', say_hello( 'hi' ) );
 ```
 
-- `and_return_second_argument()`: Shortcut for `and_return( passed_arg( 1 ) )`.
+### `and_return_second_argument()`
+
+Shortcut for `and_return( passed_arg( 1 ) )`.
 
 ```php
 Spy::stub_function( 'say_hello' )->and_return_second_argument();
 $this->assertEquals( 'there', say_hello( 'hi', 'there' ) );
 ```
 
-# SpyCall
+## SpyCall
 
 ## Instance methods
 
-- `get_args()`: Return the arguments for a call.
+### `get_args()`
+
+Return the arguments for a call.
 
 ```php
 $spy = make_spy();
@@ -341,7 +415,9 @@ $calls = $spy->get_called_functions();
 $this->assertEquals( [ 1, 2, 3 ], $calls[0]->get_args() );
 ```
 
-- `get_timestamp()`: Return the timestamp for when a call was made.
+### `get_timestamp()`
+
+Return the timestamp for when a call was made.
 
 ```php
 $spy = make_spy();
@@ -351,11 +427,13 @@ $calls = $spy->get_called_functions();
 $this->assertGreaterThan( $now, $calls[0]->get_timestamp() );
 ```
 
-# MockObject
+## MockObject
 
 ### Static methods
 
-- `mock_object()`: Shortcut for `new MockObject()`.
+### `mock_object()`
+
+Shortcut for `new MockObject()`.
 
 ```php
 $obj = Spies\MockObject::mock_object();
@@ -363,7 +441,9 @@ $obj->add_method( 'run' );
 $obj->run();
 ```
 
-- `mock_object_of( $class_name )`: Create a new `MockObject`, automatically adding a Spy for every public method in `$class_name`.
+### `mock_object_of( $class_name )`
+
+Create a new `MockObject`, automatically adding a Spy for every public method in `$class_name`.
 
 ```php
 class TestObj {
@@ -376,7 +456,9 @@ $obj->run();
 
 ### Instance methods
 
-- `add_method( $function_name, $function = null )`: Add a public method to this Object as a Spy and return that method. Creates and returns a Spy if no function is provided.
+### `add_method( $function_name, $function = null )`
+
+Add a public method to this Object as a Spy and return that method. Creates and returns a Spy if no function is provided.
 
 ```php
 $obj = Spies\MockObject::mock_object();
@@ -386,7 +468,9 @@ $obj->add_method( 'run', function( $arg ) {
 $this->assertEquals( 'hello friend', $obj->run( 'friend' ) );
 ```
 
-- `spy_on_method( $function_name, $function = null )`: Alias for `add_method()`.
+### `spy_on_method( $function_name, $function = null )`
+
+Alias for `add_method()`.
 
 ```php
 $obj = Spies\MockObject::mock_object();
@@ -396,18 +480,22 @@ expect_spy( $spy )->to_have_been_called();
 finish_spying();
 ```
 
-- `and_ignore_missing()`: Prevents throwing an Exception when an unmocked method is called on this object.
+### `and_ignore_missing()`
+
+Prevents throwing an Exception when an unmocked method is called on this object.
 
 ```php
 $mock = Spies\mock_object()->and_ignore_missing();
 $this->assertEquals( null, $mock->say_goodbye() );
 ```
 
-# Expectation
+## Expectation
 
 ### Static methods
 
-- `expect_spy( $spy )`: Create a new Expectation for the behavior of $spy.
+### `expect_spy( $spy )`
+
+Create a new Expectation for the behavior of $spy.
 
 ```php
 $spy = get_spy_for( 'wp_update_post' );
@@ -418,7 +506,9 @@ $expectation->verify();
 
 ### Instance methods
 
-- `to_be_called`: Syntactic sugar. Returns the Expectation.
+### `to_be_called`
+
+Syntactic sugar. Returns the Expectation.
 
 ```php
 $spy = get_spy_for( 'wp_update_post' );
@@ -427,7 +517,9 @@ wp_update_post();
 $expectation->verify();
 ```
 
-- `to_have_been_called`: Syntactic sugar. Returns the Expectation.
+### `to_have_been_called`
+
+Syntactic sugar. Returns the Expectation.
 
 ```php
 $spy = get_spy_for( 'wp_update_post' );
@@ -436,7 +528,9 @@ $expectation = expect_spy( $spy )->to_have_been_called();
 $expectation->verify();
 ```
 
-- `not`: When accessed, reverses all expected behaviors on this Expectation.
+### `not`
+
+When accessed, reverses all expected behaviors on this Expectation.
 
 ```php
 $spy = get_spy_for( 'wp_update_post' );
@@ -445,7 +539,9 @@ $expectation = expect_spy( $spy )->not->to_have_been_called->with( 'hello' );
 $expectation->verify();
 ```
 
-- `verify()`: Resolve and verify all the behaviors set on this Expectation.
+### `verify()`
+
+Resolve and verify all the behaviors set on this Expectation.
 
 ```php
 $spy = get_spy_for( 'wp_update_post' );
@@ -454,7 +550,9 @@ $expectation = expect_spy( $spy )->not->to_have_been_called->with( 'hello' );
 $expectation->verify();
 ```
 
-- `to_be_called()`: Add an expected behavior that the spy was called when this is resolved.
+### `to_be_called()`
+
+Add an expected behavior that the spy was called when this is resolved.
 
 ```php
 $spy = get_spy_for( 'wp_update_post' );
@@ -463,7 +561,9 @@ wp_update_post();
 $expectation->verify();
 ```
 
-- `to_have_been_called()`: Alias for `to_be_called()`.
+### `to_have_been_called()`
+
+Alias for `to_be_called()`.
 
 ```php
 $spy = get_spy_for( 'wp_update_post' );
@@ -472,7 +572,9 @@ $expectation = expect_spy( $spy )->to_have_been_called();
 $expectation->verify();
 ```
 
-- `with( $arg... )`: Add an expected behavior that the spy was called with particular arguments when this is resolved.
+### `with( $arg... )`
+
+Add an expected behavior that the spy was called with particular arguments when this is resolved.
 
 ```php
 $spy = get_spy_for( 'wp_update_post' );
@@ -481,7 +583,9 @@ $expectation = expect_spy( $spy )->to_have_been_called->with( 'hello' );
 $expectation->verify();
 ```
 
-- `when( $callable )`: Return true if the passed function returns true at least once. For each spy call, the function will be called with the arguments from that call.
+### `when( $callable )`
+
+Return true if the passed function returns true at least once. For each spy call, the function will be called with the arguments from that call.
 
 ```php
 $spy = make_spy();
@@ -492,7 +596,9 @@ expect_spy( $spy )->to_have_been_called->when( function( $args ) {
 finish_spying();
 ```
 
-- `times( $count )`: Add an expected behavior that the spy was called exactly $count times.
+### `times( $count )`
+
+Add an expected behavior that the spy was called exactly $count times.
 
 ```php
 $spy = make_spy();
@@ -502,7 +608,9 @@ expect_spy( $spy )->to_have_been_called->times( 2 );
 finish_spying();
 ```
 
-- `once()`: Alias for `times( 1 )`.
+### `once()`
+
+Alias for `times( 1 )`.
 
 ```php
 $spy = make_spy();
@@ -511,7 +619,9 @@ expect_spy( $spy )->to_have_been_called->once();
 finish_spying();
 ```
 
-- `twice()`: Alias for `times( 2 )`.
+### `twice()`
+
+Alias for `times( 2 )`.
 
 ```php
 $spy = make_spy();
@@ -521,7 +631,9 @@ expect_spy( $spy )->to_have_been_called->twice();
 finish_spying();
 ```
 
-- `before( $spy )`: Add an expected behavior that the spy was called before $spy.
+### `before( $spy )`
+
+Add an expected behavior that the spy was called before $spy.
 
 ```php
 $spy = make_spy();
@@ -532,21 +644,21 @@ expect_spy( $spy )->to_have_been_called->before( $spy2 );
 finish_spying();
 ```
 
-# PHPUnit Custom Assertions
+## PHPUnit Custom Assertions
 
 These are methods available on instances of `\Spies\TestCase`.
 
 ### Constraints for `assertThat()`
 
-- `wasCalled()`
-- `wasNotCalled()`
-- `wasCalledTimes( $count )`
-- `wasCalledBefore( $spy )`
-- `wasCalledWhen( $callable )`
+### `wasCalled()`
+### `wasNotCalled()`
+### `wasCalledTimes( $count )`
+### `wasCalledBefore( $spy )`
+### `wasCalledWhen( $callable )`
 
 ### Assertions
 
-- `assertSpyWasCalled( $spy )`
+### `assertSpyWasCalled( $spy )`
 
 ```php
 $spy = Spy::get_spy_for( 'say_hello' );
@@ -554,14 +666,14 @@ say_hello();
 $this->assertSpyWasCalled( $spy );
 ```
 
-- `assertSpyWasNotCalled( $spy )`
+### `assertSpyWasNotCalled( $spy )`
 
 ```php
 $spy = Spy::get_spy_for( 'say_hello' );
 $this->assertSpyWasNotCalled( $spy );
 ```
 
-- `assertSpyWasCalledWith( $spy, $args )`
+### `assertSpyWasCalledWith( $spy, $args )`
 
 ```php
 $spy = Spy::get_spy_for( 'say_hello' );
@@ -569,7 +681,7 @@ say_hello( 'friend' );
 $this->assertSpyWasCalledWith( $spy, [ 'friend' ] );
 ```
 
-- `assertSpyWasNotCalledWith( $spy, $args )`
+### `assertSpyWasNotCalledWith( $spy, $args )`
 
 ```php
 $spy = Spy::get_spy_for( 'say_hello' );
@@ -577,7 +689,7 @@ say_hello( 'robot' );
 $this->assertSpyWasNotCalledWith( $spy, [ 'friend' ] );
 ```
 
-- `assertSpyWasCalledTimes( $spy, $count )`
+### `assertSpyWasCalledTimes( $spy, $count )`
 
 ```php
 $spy = Spy::get_spy_for( 'say_hello' );
@@ -586,7 +698,7 @@ say_hello( 'robot' );
 $this->assertSpyWasCalledTimes( $spy, 2 );
 ```
 
-- `assertSpyWasNotCalledTimes( $spy, $count )`
+### `assertSpyWasNotCalledTimes( $spy, $count )`
 
 ```php
 $spy = Spy::get_spy_for( 'say_hello' );
@@ -595,7 +707,7 @@ say_hello( 'robot' );
 $this->assertSpyWasNotCalledTimes( $spy, 3 );
 ```
 
-- `assertSpyWasCalledTimesWith( $spy, $count, $args )`
+### `assertSpyWasCalledTimesWith( $spy, $count, $args )`
 
 ```php
 $spy = Spy::get_spy_for( 'say_hello' );
@@ -604,7 +716,7 @@ say_hello( 'friend' );
 $this->assertSpyWasCalledTimesWith( $spy, 2, [ 'friend' ] );
 ```
 
-- `assertSpyWasNotCalledTimesWith( $spy, $count, $args )`
+### `assertSpyWasNotCalledTimesWith( $spy, $count, $args )`
 
 ```php
 $spy = Spy::get_spy_for( 'say_hello' );
@@ -613,7 +725,7 @@ say_hello( 'robot' );
 $this->assertSpyWasNotCalledTimesWith( $spy, 2, [ 'friend' ] );
 ```
 
-- `assertSpyWasCalledBefore( $spy, $other_spy )`
+### `assertSpyWasCalledBefore( $spy, $other_spy )`
 
 ```php
 $spy = Spy::get_spy_for( 'say_hello' );
@@ -623,7 +735,7 @@ say_goodbye();
 $this->assertSpyWasCalledBefore( $spy, $other_spy );
 ```
 
-- `assertSpyWasNotCalledBefore( $spy, $other_spy )`
+### `assertSpyWasNotCalledBefore( $spy, $other_spy )`
 
 ```php
 $spy = Spy::get_spy_for( 'say_hello' );
@@ -633,7 +745,7 @@ say_hello();
 $this->assertSpyWasNotCalledBefore( $spy, $other_spy );
 ```
 
-- `assertSpyWasCalledWhen( $spy, $callable )`
+### `assertSpyWasCalledWhen( $spy, $callable )`
 
 ```php
 $spy = Spy::get_spy_for( 'say_hello' );
@@ -643,7 +755,7 @@ $this->assertSpyWasCalledWhen( $spy, function( $args ) {
 } );
 ```
 
-- `assertSpyWasNotCalledWhen( $spy, $callable )`
+### `assertSpyWasNotCalledWhen( $spy, $callable )`
 
 ```php
 $spy = Spy::get_spy_for( 'say_hello' );

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ function test_greeter() {
 	$say_goodbye = $mock->spy_on_method( 'say_goodbye' );
 	$mock->add_method( 'say_hello' )->that_returns( 'greetings' );
 	$this->assertEquals( 'greetings', $mock->say_hello() );
-	$this->assertEquals( 'goodbye, $mock->say_goodbye() );
+	$this->assertEquals( 'goodbye', $mock->say_goodbye() );
 	$this->assertSpyWasCalled( $say_goodbye );
 }
 ```

--- a/README.md
+++ b/README.md
@@ -221,6 +221,33 @@ function test_greeter() {
 }
 ```
 
+## Object Method Delegation
+
+Sometimes it's helpful to be able to be able to spy on actual methods of an object, or to replace some methods on an object, but not others. This involves creating a delegate object, which can be done by passing a class instance to `\Spies\mock_object()`.
+
+The resulting `MockObject` will forward all method calls to the original class instance, except those overridden by using `add_method()`. It's possible to use `spy_on_method()` to spy on any method call of the object, just as you would do with a regular MockObject.
+
+```php
+class Greeter {
+	public function say_hello() {
+		return 'hello';
+	}
+
+	public function say_goodbye() {
+		return 'goodbye';
+	}
+}
+
+function test_greeter() {
+	$mock = \Spies\mock_object( new Greeter() );
+	$say_goodbye = $mock->spy_on_method( 'say_goodbye' );
+	$mock->add_method( 'say_hello' )->that_returns( 'greetings' );
+	$this->assertEquals( 'greetings', $mock->say_hello() );
+	$this->assertEquals( 'goodbye, $mock->say_goodbye() );
+	$this->assertSpyWasCalled( $say_goodbye );
+}
+```
+
 ## Expectations
 
 Spies can be useful all by themselves, but Spies also provides the `Expectation` class to make writing your test expectations easier.

--- a/src/Spies/Helpers.php
+++ b/src/Spies/Helpers.php
@@ -49,4 +49,10 @@ class Helpers {
 	public static function do_arrays_match( $a, $b ) {
 		return self::do_vals_match( $a, $b );
 	}
+
+	public static function make_spy_from_function( $function ) {
+		$spy = new Spy();
+		$spy->will_return( $function );
+		return $spy;
+	}
 }

--- a/src/Spies/InvalidFunctionNameException.php
+++ b/src/Spies/InvalidFunctionNameException.php
@@ -1,0 +1,6 @@
+<?php
+namespace Spies;
+
+class InvalidFunctionNameException extends \Exception {
+}
+

--- a/src/Spies/MockObject.php
+++ b/src/Spies/MockObject.php
@@ -113,10 +113,10 @@ class MockObject {
 			'and_ignore_missing',
 		];
 		if ( in_array( $function_name, $reserved_method_names ) ) {
-			throw new \Exception( 'The function "' . $function_name . '" added to this mock object could not be used because it conflicts with a built-in function' );
+			throw new \Spies\InvalidFunctionNameException( 'The function "' . $function_name . '" added to this mock object could not be used because it conflicts with a built-in function' );
 		}
 		if ( ! is_callable( $function ) ) {
-			throw new \Exception( 'The function "' . $function_name . '" added to this mock object was not a function' );
+			throw new \InvalidArgumentException( 'The function "' . $function_name . '" added to this mock object was not a function' );
 		}
 		if ( $function instanceof Spy && $this->delegate_instance ) {
 			$function->will_return( [ $this->delegate_instance, $function_name ] );

--- a/src/Spies/MockObject.php
+++ b/src/Spies/MockObject.php
@@ -70,13 +70,11 @@ class MockObject {
 	/**
 	 * Spy on a method on this object
 	 *
-	 * If the method does not already exist, this is an alias for `add_method()`.
-	 * If the method _does_ exist, this will install a Spy on the existing method
-	 * and return that Spy.
+	 * Alias for `add_method()`.
 	 *
 	 * @param string $function_name The name of the function to add to this object
-	 * @param Spy|callback $function optional A callable function or Spy to be used when the new method is called. Defaults to a new Spy.
-	 * @return Spy|callback The Spy or callback
+	 * @param Spy|function $function optional A callable function or Spy to be used when the new method is called. Defaults to a new Spy.
+	 * @return Spy|function The Spy or callback
 	 */
 	public function spy_on_method( $function_name, $function = null ) {
 		return $this->add_method( $function_name, $function );
@@ -97,8 +95,8 @@ class MockObject {
 	 * `$mock_object->add_method( 'do_something' )->that_returns( 'hello world' );`
 	 *
 	 * @param string $function_name The name of the function to add to this object
-	 * @param Spy|callback $function optional A callable function or Spy to be used when the new method is called. Defaults to a new Spy.
-	 * @return Spy|callback The Spy or callback
+	 * @param Spy|function $function optional A callable function or Spy to be used when the new method is called. Defaults to a new Spy.
+	 * @return Spy|function The Spy or callback
 	 */
 	public function add_method( $function_name, $function = null ) {
 		if ( ! isset( $function ) ) {

--- a/src/Spies/MockObject.php
+++ b/src/Spies/MockObject.php
@@ -3,13 +3,42 @@ namespace Spies;
 
 class MockObject {
 
+	private $spies_on_methods = [];
 	private $class_name = null;
-
 	private $ignore_missing_methods = false;
 
+	/**
+	 * Create a new MockObject
+	 *
+	 * If passed nothing, the MockObject will have no methods. Methods can be
+	 * added by using the `add_method()` method (hopefully you don't need to add
+	 * a method called `add_method` or you're out of luck). That method allows
+	 * passing a function to use as the method or it returns a Stub (which is a
+	 * Spy) that can be used to program the method using the usual Stub API.
+	 *
+	 * If passed a class name, the MockObject will automatically have Stub
+	 * methods added for each method of the class you specified. These methods
+	 * will, by default, do nothing. It is still possible, then, to use
+	 * `add_method()` to add new methods or to modify the behavior of existing
+	 * methods.
+	 *
+	 * Normally, if a method is called on the MockObject which has not been
+	 * defined by `add_method()`, an Exception will be thrown. However, if you
+	 * want to allow and ignore any un-mocked methods, you can call
+	 * `and_ignore_missing()` on the MockObject.
+	 *
+	 * In all of these cases, the methods of the MockObject can be used as Spies
+	 * to determine their usage. To spy on a method in this class, call
+	 * `spy_on_method()`.
+	 *
+	 * @param string $class_name optional. The class to mock.
+	 */
 	public function __construct( $class_name = null ) {
 		$this->class_name = $class_name;
 		if ( isset( $class_name ) ) {
+			if ( ! class_exists( $class_name ) ) {
+				throw new \Exception( 'The class "' . $class_name . '" does not exist and could not be used to create a MockObject' );
+			}
 			array_map( [ $this, 'add_method' ], get_class_methods( $class_name ) );
 		}
 	}
@@ -25,13 +54,20 @@ class MockObject {
 	}
 
 	/**
- 	 * Alias for add_method
+	 * Spy on a method on this object
+	 *
+	 * If the method does not already exist, this is an alias for `add_method()`.
+	 * If the method _does_ exist, this will install a Spy on the existing method
+	 * and return that Spy.
 	 *
 	 * @param string $function_name The name of the function to add to this object
 	 * @param Spy|callback $function optional A callable function or Spy to be used when the new method is called. Defaults to a new Spy.
 	 * @return Spy|callback The Spy or callback
 	 */
 	public function spy_on_method( $function_name, $function = null ) {
+		if ( isset( $this->spies_on_methods[ $function_name ] ) ) {
+			return $this->spies_on_methods[ $function_name ];
+		}
 		return $this->add_method( $function_name, $function );
 	}
 
@@ -57,13 +93,23 @@ class MockObject {
 		if ( ! isset( $function ) ) {
 			$function = isset( $this->$function_name ) ? $this->$function_name : new \Spies\Spy();
 		}
+		$reserved_method_names = [
+			'add_method',
+			'spy_on_method',
+			'and_ignore_missing',
+		];
+		if ( in_array( $function_name, $reserved_method_names ) ) {
+			throw new \Exception( 'The function "' . $function_name . '" added to this mock object could not be used because it conflicts with a built-in function' );
+		}
 		if ( ! is_callable( $function ) ) {
 			throw new \Exception( 'The function "' . $function_name . '" added to this mock object was not a function' );
 		}
 		if ( $function instanceof Spy ) {
 			$function->set_function_name( $function_name );
 		}
+		$function_spy = ( $function instanceof Spy ) ? $function : new \Spies\Spy();
 		$this->$function_name = $function;
+		$this->spies_on_methods[ $function_name ] = $function_spy;
 		return $function;
 	}
 
@@ -77,11 +123,11 @@ class MockObject {
 		return $this;
 	}
 
-	public static function mock_object( $class_name = null) {
+	public static function mock_object( $class_name = null ) {
 		return new MockObject( $class_name );
 	}
 
-	public static function mock_object_of( $class_name = null) {
+	public static function mock_object_of( $class_name = null ) {
 		return new MockObject( $class_name );
 	}
 }

--- a/src/Spies/MockObject.php
+++ b/src/Spies/MockObject.php
@@ -44,17 +44,22 @@ class MockObject {
 			return;
 		}
 		if ( is_string( $instance_or_class_name ) ) {
-			$class_name = $instance_or_class_name;
-			$this->class_name = $class_name;
-			if ( ! class_exists( $class_name ) ) {
-				throw new \Exception( 'The class "' . $class_name . '" does not exist and could not be used to create a MockObject' );
-			}
-			array_map( [ $this, 'add_method' ], get_class_methods( $class_name ) );
-			return;
+			return $this->create_mock_object_for_class( $instance_or_class_name );
 		}
-		$instance = $instance_or_class_name;
+		$this->create_mock_object_for_delegate( $instance_or_class_name );
+	}
+
+	private function create_mock_object_for_delegate( $instance ) {
 		$this->delegate_instance = $instance;
 		array_map( [ $this, 'add_method' ], get_class_methods( get_class( $instance ) ) );
+	}
+
+	private function create_mock_object_for_class( $class_name ) {
+		$this->class_name = $class_name;
+		if ( ! class_exists( $class_name ) ) {
+			throw new \Exception( 'The class "' . $class_name . '" does not exist and could not be used to create a MockObject' );
+		}
+		array_map( [ $this, 'add_method' ], get_class_methods( $class_name ) );
 	}
 
 	public function __call( $function_name, $args ) {

--- a/src/Spies/functions.php
+++ b/src/Spies/functions.php
@@ -31,8 +31,8 @@ function finish_spying() {
 	\Spies\GlobalSpies::restore_original_global_functions();
 }
 
-function mock_object() {
-	return \Spies\MockObject::mock_object();
+function mock_object( $instance = null ) {
+	return \Spies\MockObject::mock_object( $instance );
 }
 
 function mock_object_of( $class_name = null ) {

--- a/tests/MockObjectTest.php
+++ b/tests/MockObjectTest.php
@@ -8,6 +8,10 @@ class Greeter {
 	public function say_goodbye() {
 		return 'goodbye';
 	}
+
+	public function just_say( $what ) {
+		return 'yo' . $what;
+	}
 }
 
 /**
@@ -88,10 +92,35 @@ class MockObjectTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 'hello', $mock->say_hello() );
 	}
 
+	public function test_mock_object_with_instance_delegates_methods_to_instance_methods_with_arguments() {
+		$mock = \Spies\mock_object( new Greeter() );
+		$this->assertEquals( 'yono', $mock->just_say( 'no' ) );
+	}
+
 	public function test_add_method_on_a_delegate_instance_overrides_the_instance_method() {
 		$mock = \Spies\mock_object( new Greeter() );
 		$mock->add_method( 'say_hello' )->that_returns( 'greetings' );
 		$this->assertEquals( 'greetings', $mock->say_hello() );
+	}
+
+	public function test_add_method_on_a_delegate_instance_overrides_the_instance_method_only_if_conditions_are_met() {
+		$mock = \Spies\mock_object( new Greeter() );
+		$mock->add_method( 'just_say' )->when_called->with( 'no' )->will_return( 'nope' );
+		$this->assertEquals( 'yoyes', $mock->just_say( 'yes' ) );
+	}
+
+	public function test_add_method_on_a_delegate_instance_overrides_the_instance_method_and_receives_its_arguments() {
+		$mock = \Spies\mock_object( new Greeter() );
+		$mock->add_method( 'just_say' )->when_called->with( 'no' )->will_return( 'nope' );
+		$this->assertEquals( 'nope', $mock->just_say( 'no' ) );
+	}
+
+	public function test_add_method_with_return_function_on_a_delegate_instance_overrides_the_instance_method_and_receives_its_arguments() {
+		$mock = \Spies\mock_object( new Greeter() );
+		$mock->add_method( 'just_say' )->when_called->with( 'cool' )->will_return( function( $arg ) {
+			return $arg . ' is cool';
+		} );
+		$this->assertEquals( 'cool is cool', $mock->just_say( 'cool' ) );
 	}
 
 	public function test_spy_on_method_for_a_delegate_instance_which_was_overridden_returns_spy_which_is_triggered_by_method() {

--- a/tests/MockObjectTest.php
+++ b/tests/MockObjectTest.php
@@ -131,6 +131,14 @@ class MockObjectTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 'cool is cool', $mock->just_say( 'cool' ) );
 	}
 
+	public function test_add_method_with_a_function_on_a_class_mock_sends_the_arguments_to_the_function() {
+		$mock = \Spies\mock_object( 'Greeter' );
+		$mock->add_method( 'just_say', function( $what ) {
+			return 'just ' . $what;
+		} );
+		$this->assertEquals( 'just thanks', $mock->just_say( 'thanks' ) );
+	}
+
 	public function test_spy_on_method_for_a_class_which_was_overridden_with_a_function_returns_spy_which_is_triggered_by_method() {
 		$mock = \Spies\mock_object( 'Greeter' );
 		$mock->add_method( 'just_say', function( $what ) {

--- a/tests/MockObjectTest.php
+++ b/tests/MockObjectTest.php
@@ -103,6 +103,14 @@ class MockObjectTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 'greetings', $mock->say_hello() );
 	}
 
+	public function test_add_method_with_a_function_on_a_delegate_instance_sends_the_arguments_to_the_function() {
+		$mock = \Spies\mock_object( new Greeter() );
+		$mock->add_method( 'just_say', function( $what ) {
+			return 'just ' . $what;
+		} );
+		$this->assertEquals( 'just thanks', $mock->just_say( 'thanks' ) );
+	}
+
 	public function test_add_method_on_a_delegate_instance_overrides_the_instance_method_only_if_conditions_are_met() {
 		$mock = \Spies\mock_object( new Greeter() );
 		$mock->add_method( 'just_say' )->when_called->with( 'no' )->will_return( 'nope' );
@@ -121,6 +129,26 @@ class MockObjectTest extends PHPUnit_Framework_TestCase {
 			return $arg . ' is cool';
 		} );
 		$this->assertEquals( 'cool is cool', $mock->just_say( 'cool' ) );
+	}
+
+	public function test_spy_on_method_for_a_class_which_was_overridden_with_a_function_returns_spy_which_is_triggered_by_method() {
+		$mock = \Spies\mock_object( 'Greeter' );
+		$mock->add_method( 'just_say', function( $what ) {
+			return 'saying ' . $what;
+		} );
+		$spy = $mock->spy_on_method( 'just_say' );
+		$mock->just_say( 'hi' );
+		$this->assertTrue( $spy->was_called_with( 'hi' ) );
+	}
+
+	public function test_spy_on_method_for_a_delegate_instance_which_was_overridden_with_a_function_returns_spy_which_is_triggered_by_method() {
+		$mock = \Spies\mock_object( new Greeter() );
+		$mock->add_method( 'just_say', function( $what ) {
+			return 'saying ' . $what;
+		} );
+		$spy = $mock->spy_on_method( 'just_say' );
+		$mock->just_say( 'hi' );
+		$this->assertTrue( $spy->was_called_with( 'hi' ) );
 	}
 
 	public function test_spy_on_method_for_a_delegate_instance_which_was_overridden_returns_spy_which_is_triggered_by_method() {

--- a/tests/MockObjectTest.php
+++ b/tests/MockObjectTest.php
@@ -227,4 +227,28 @@ class MockObjectTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 5, $mock->test_stub( 'hello' ) );
 		$this->assertEquals( 6, $mock->test_stub( 'bar' ) );
 	}
+
+	public function test_mock_object_throws_error_when_mocking_reserved_method_name_add_method() {
+		$this->setExpectedException( '\Spies\InvalidFunctionNameException' );
+		$mock = \Spies\mock_object();
+		$mock->add_method( 'add_method' );
+	}
+
+	public function test_mock_object_throws_error_when_mocking_reserved_method_name_spy_on_method() {
+		$this->setExpectedException( '\Spies\InvalidFunctionNameException' );
+		$mock = \Spies\mock_object();
+		$mock->add_method( 'spy_on_method' );
+	}
+
+	public function test_mock_object_throws_error_when_mocking_reserved_method_name_and_ignore_missing() {
+		$this->setExpectedException( '\Spies\InvalidFunctionNameException' );
+		$mock = \Spies\mock_object();
+		$mock->add_method( 'and_ignore_missing' );
+	}
+
+	public function test_mock_object_throws_error_when_mocking_with_a_non_function() {
+		$this->setExpectedException( 'InvalidArgumentException' );
+		$mock = \Spies\mock_object();
+		$mock->add_method( 'foobar', 42 );
+	}
 }

--- a/tests/MockObjectTest.php
+++ b/tests/MockObjectTest.php
@@ -62,11 +62,49 @@ class MockObjectTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( null, $mock->say_goodbye() );
 	}
 
-	public function test_spy_on_method_is_an_alias_for_add_method() {
+	public function test_spy_on_method_for_non_existent_method_is_an_alias_for_add_method() {
 		$mock = \Spies\mock_object_of( 'Greeter' );
 		$mock->spy_on_method( 'say_hello' )->that_returns( 'greetings' );
 		$this->assertEquals( 'greetings', $mock->say_hello() );
 		$this->assertEquals( null, $mock->say_goodbye() );
+	}
+
+	public function test_spy_on_method_for_existing_method_stub_does_not_override_method() {
+		$mock = \Spies\mock_object();
+		$mock->add_method( 'say_hello' )->that_returns( 'greetings' );
+		$mock->spy_on_method( 'say_hello' );
+		$this->assertEquals( 'greetings', $mock->say_hello() );
+	}
+
+	public function test_mock_object_with_instance_delegates_methods_to_instance_methods() {
+		$mock = \Spies\mock_object( new Greeter() );
+		$this->assertEquals( 'hello', $mock->say_hello() );
+	}
+
+	public function test_add_method_on_a_delegate_instance_overrides_the_instance_method() {
+		$mock = \Spies\mock_object( new Greeter() );
+		$this->assertEquals( 'hello', $mock->say_hello() );
+	}
+
+	public function test_spy_on_method_for_a_delegate_instance_does_not_override_the_instance_method() {
+		$mock = \Spies\mock_object( new Greeter() );
+		$mock->spy_on_method( 'say_hello' );
+		$this->assertEquals( 'hello', $mock->say_hello() );
+	}
+
+	public function test_spy_on_method_for_existing_method_stub_returns_spy_which_is_triggered_by_existing_method() {
+		$mock = \Spies\mock_object();
+		$mock->add_method( 'say_hello' )->that_returns( 'greetings' );
+		$spy = $mock->spy_on_method( 'say_hello' );
+		$mock->say_hello();
+		$this->assertTrue( $spy->was_called() );
+	}
+
+	public function test_spy_on_method_for_existing_real_method_returns_spy_which_is_triggered_by_existing_method() {
+		$mock = \Spies\mock_object_of( 'Greeter' );
+		$spy = $mock->spy_on_method( 'say_hello' );
+		$mock->say_hello();
+		$this->assertTrue( $spy->was_called() );
 	}
 
 	public function test_mock_object_throws_error_when_unmocked_method_is_called() {

--- a/tests/MockObjectTest.php
+++ b/tests/MockObjectTest.php
@@ -83,13 +83,21 @@ class MockObjectTest extends PHPUnit_Framework_TestCase {
 
 	public function test_add_method_on_a_delegate_instance_overrides_the_instance_method() {
 		$mock = \Spies\mock_object( new Greeter() );
-		$this->assertEquals( 'hello', $mock->say_hello() );
+		$mock->add_method( 'say_hello' )->that_returns( 'greetings' );
+		$this->assertEquals( 'greetings', $mock->say_hello() );
 	}
 
 	public function test_spy_on_method_for_a_delegate_instance_does_not_override_the_instance_method() {
 		$mock = \Spies\mock_object( new Greeter() );
 		$mock->spy_on_method( 'say_hello' );
 		$this->assertEquals( 'hello', $mock->say_hello() );
+	}
+
+	public function test_spy_on_method_for_a_delegate_instance_returns_spy_which_is_triggered_by_existing_method() {
+		$mock = \Spies\mock_object( new Greeter() );
+		$spy = $mock->spy_on_method( 'say_hello' );
+		$mock->say_hello();
+		$this->assertTrue( $spy->was_called() );
 	}
 
 	public function test_spy_on_method_for_existing_method_stub_returns_spy_which_is_triggered_by_existing_method() {

--- a/tests/MockObjectTest.php
+++ b/tests/MockObjectTest.php
@@ -87,6 +87,14 @@ class MockObjectTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 'greetings', $mock->say_hello() );
 	}
 
+	public function test_spy_on_method_for_a_delegate_instance_which_was_overridden_returns_spy_which_is_triggered_by_method() {
+		$mock = \Spies\mock_object( new Greeter() );
+		$mock->add_method( 'say_hello' )->that_returns( 'greetings' );
+		$spy = $mock->spy_on_method( 'say_hello' );
+		$mock->say_hello();
+		$this->assertTrue( $spy->was_called() );
+	}
+
 	public function test_spy_on_method_for_a_delegate_instance_does_not_override_the_instance_method() {
 		$mock = \Spies\mock_object( new Greeter() );
 		$mock->spy_on_method( 'say_hello' );

--- a/tests/MockObjectTest.php
+++ b/tests/MockObjectTest.php
@@ -69,11 +69,18 @@ class MockObjectTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( null, $mock->say_goodbye() );
 	}
 
-	public function test_spy_on_method_for_existing_method_stub_does_not_override_method() {
+	public function test_spy_on_method_for_existing_method_stub_does_not_break_method() {
 		$mock = \Spies\mock_object();
 		$mock->add_method( 'say_hello' )->that_returns( 'greetings' );
 		$mock->spy_on_method( 'say_hello' );
 		$this->assertEquals( 'greetings', $mock->say_hello() );
+	}
+
+	public function test_spy_on_method_for_existing_method_stub_returns_the_stub() {
+		$mock = \Spies\mock_object();
+		$mock->add_method( 'say_hello' )->that_returns( 'greetings' );
+		$mock->spy_on_method( 'say_hello' )->that_returns( 'foobar' );
+		$this->assertEquals( 'foobar', $mock->say_hello() );
 	}
 
 	public function test_mock_object_with_instance_delegates_methods_to_instance_methods() {
@@ -95,10 +102,16 @@ class MockObjectTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue( $spy->was_called() );
 	}
 
-	public function test_spy_on_method_for_a_delegate_instance_does_not_override_the_instance_method() {
+	public function test_spy_on_method_for_a_delegate_instance_does_not_break_the_instance_method() {
 		$mock = \Spies\mock_object( new Greeter() );
 		$mock->spy_on_method( 'say_hello' );
 		$this->assertEquals( 'hello', $mock->say_hello() );
+	}
+
+	public function test_spy_on_method_for_a_delegate_instance_returns_stub_which_can_override_the_instance_method() {
+		$mock = \Spies\mock_object( new Greeter() );
+		$mock->spy_on_method( 'say_hello' )->will_return( 'foobar' );
+		$this->assertEquals( 'foobar', $mock->say_hello() );
 	}
 
 	public function test_spy_on_method_for_a_delegate_instance_returns_spy_which_is_triggered_by_existing_method() {
@@ -116,7 +129,7 @@ class MockObjectTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue( $spy->was_called() );
 	}
 
-	public function test_spy_on_method_for_existing_real_method_returns_spy_which_is_triggered_by_existing_method() {
+	public function test_spy_on_method_for_mock_object_method_returns_spy_which_is_triggered_by_existing_method() {
 		$mock = \Spies\mock_object_of( 'Greeter' );
 		$spy = $mock->spy_on_method( 'say_hello' );
 		$mock->say_hello();


### PR DESCRIPTION
This modifies `MockObject` such that if provided with a class instance rather than a class name, it will delegate all method calls on the mock object to the delegate instance. 

However, the mock will still retain the features of a `MockObject`, like being able to add additional methods (using `add_method()`) and being able to spy on method calls (using `spy_on_method()`).

That is, this now works:

```php
class ExistingObject {
  public function existing_method() {}
}
$mock = \Spies\mock_object( new ExistingObject() );
$mock->existing_method();
```

~Previously, `spy_on_method()` was simply an alias to `add_method()`, but with this change they have slightly different behaviors. `add_method()` still adds (and overrides) methods on the object. `spy_on_method()` now has two behaviors; if the method in question does not exist, it still acts as an alias to `add_method()`. If the method _does_ exist, then it _does not_ override the existing method and instead returns a `Spy` which is triggered when the method is called.~

This change makes it possible to create a sort of proxy object which functions as normal, but allows spying on its method calls.

It also means that it's possible to mock certain methods of an object while retaining the full functionality of other methods.

- [x] Verify that arguments are passed through to delegate methods
- [x] Verify that return values are passed back from delegate methods
- [x] Verify that `spy_on_method()` works for methods where `add_method()` was passed a function
- [x] Update docs
- [x] Add tests for exceptions thrown on reserved mock_object method names