### PR TITLE
Separate phpunit from Expectations

### DIFF
--- a/API.md
+++ b/API.md
@@ -578,11 +578,36 @@ $expectation->verify();
 
 Resolve and verify all the behaviors set on this Expectation.
 
+If any behavior is false, this will throw an `\Spies\UnmetExpectationException`. If PHPUnit is loaded the Exception will be a subclass of `PHPUnit_Framework_ExpectationFailedException`.
+
 ```php
 $spy = get_spy_for( 'wp_update_post' );
 wp_update_post( 'bye' );
 $expectation = expect_spy( $spy )->not->to_have_been_called->with( 'hello' );
 $expectation->verify();
+```
+
+### `met_expectations()`
+
+Returns true if all behaviors in this Expectation are met.
+
+```php
+$spy = get_spy_for( 'wp_update_post' );
+wp_update_post( 'bye' );
+$expectation = expect_spy( $spy )->not->to_have_been_called->with( 'hello' );
+$this->assertTrue( $expectation->met_expectations() );
+```
+
+### `get_fail_message()`
+
+Returns the first failure message for the behaviors on this Expectation.
+
+Returns null if no behaviors failed.
+
+```php
+$spy = make_spy();
+$expectation = expect_spy( $spy )->to_have_been_called();
+$this->assertContains( 'Failed asserting that a spy is called', $expectation->get_fail_message() );
 ```
 
 ### `to_be_called()`

--- a/src/Spies/BaseConstraint.php
+++ b/src/Spies/BaseConstraint.php
@@ -3,4 +3,6 @@
 namespace Spies;
 
 abstract class BaseConstraint {
+	public function __construct() {
+	}
 }

--- a/src/Spies/BaseConstraint.php
+++ b/src/Spies/BaseConstraint.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace Spies;
+
+abstract class BaseConstraint {
+}

--- a/src/Spies/BaseConstraint.php
+++ b/src/Spies/BaseConstraint.php
@@ -5,4 +5,12 @@ namespace Spies;
 abstract class BaseConstraint {
 	public function __construct() {
 	}
+
+	public function failureDescription( $other ) {
+		return '';
+	}
+
+	public function additionalFailureDescription( $other ) {
+		return '';
+	}
 }

--- a/src/Spies/Expectation.php
+++ b/src/Spies/Expectation.php
@@ -55,6 +55,10 @@ class Expectation {
 	public function verify() {
 		$message = $this->get_fail_message();
 		if ( $message !== null ) {
+			// TODO: is there a way to put this in a PHPUnit-only file?
+			if ( class_exists( '\PHPUnit_Framework_AssertionFailedError' ) ) {
+				throw new \PHPUnit_Framework_AssertionFailedError( $message );
+			}
 			throw new UnmetExpectationException( $message );
 		}
 	}

--- a/src/Spies/Expectation.php
+++ b/src/Spies/Expectation.php
@@ -55,10 +55,6 @@ class Expectation {
 	public function verify() {
 		$message = $this->get_fail_message();
 		if ( $message !== null ) {
-			// TODO: is there a way to put this in a PHPUnit-only file?
-			if ( class_exists( '\PHPUnit_Framework_ExpectationFailedException' ) ) {
-				throw new \PHPUnit_Framework_ExpectationFailedException( $message );
-			}
 			throw new UnmetExpectationException( $message );
 		}
 	}

--- a/src/Spies/Expectation.php
+++ b/src/Spies/Expectation.php
@@ -199,18 +199,7 @@ class Expectation {
 	}
 
 	public function before( $target_spy ) {
-		$this->delay_expectation( function() use ( $target_spy ) {
-			if ( $this->negation ) {
-				if ( $this->silent_failures ) {
-					return ! ( new SpiesConstraintWasCalledBefore( $target_spy ) )->matches( $this->spy );
-				}
-				return \Spies\TestCase::assertSpyWasNotCalledBefore( $this->spy, $target_spy );
-			}
-			if ( $this->silent_failures ) {
-					return ( new SpiesConstraintWasCalledBefore( $target_spy ) )->matches( $this->spy );
-			}
-			return \Spies\TestCase::assertSpyWasCalledBefore( $this->spy, $target_spy );
-		} );
+		$this->add_expectation_for_constraint( new SpiesConstraintWasCalledBefore( $target_spy, $this->negation ) );
 		return $this;
 	}
 

--- a/src/Spies/Expectation.php
+++ b/src/Spies/Expectation.php
@@ -48,12 +48,15 @@ class Expectation {
 	}
 
 	/**
-	 * Alias for get_fail_message
+	 * Throws an Exception if any behavior in this Expectation fails
 	 *
-	 * @return string|null The first failure description if there is a failure
+	 * @return null
 	 */
 	public function verify() {
-		return $this->get_fail_message();
+		$message = $this->get_fail_message();
+		if ( $message !== null ) {
+			throw new UnmetExpectationException( $message );
+		}
 	}
 
 	/**

--- a/src/Spies/Expectation.php
+++ b/src/Spies/Expectation.php
@@ -48,27 +48,12 @@ class Expectation {
 	}
 
 	/**
- 	 * Verify all behaviors in this Expectation
-	 *
-	 * By default it will use PHPUnit to create assertions for
-	 * each behavior.
-	 *
-	 * If `silent_failures` is set to true, it will return true or false instead
-	 * making a PHPUnit assertion
+	 * Alias for get_fail_message
 	 *
 	 * @return string|null The first failure description if there is a failure
 	 */
 	public function verify() {
-		$this->was_verified = true;
-		foreach( $this->delayed_expectations as $behavior ) {
-			$description = call_user_func( $behavior );
-			if ( $description !== null ) {
-				if ( $this->silent_failures ) {
-					return false;
-				}
-				return $description;
-			}
-		}
+		return $this->get_fail_message();
 	}
 
 	/**

--- a/src/Spies/Expectation.php
+++ b/src/Spies/Expectation.php
@@ -129,8 +129,7 @@ class Expectation {
 			return $this->when( $args[0] );
 		}
 		$this->expected_args = $args;
-		// TODO: deal with negation
-		$this->add_expectation_for_constraint( new SpiesConstraintWasCalledWith( $this->expected_args ) );
+		$this->add_expectation_for_constraint( new SpiesConstraintWasCalledWith( $this->expected_args, $this->negation ) );
 		return $this;
 	}
 
@@ -202,7 +201,7 @@ class Expectation {
 	 * @return Expectation This Expectation to allow chaining
 	 */
 	public function times( $count ) {
-		$constraint = new SpiesConstraintWasCalledTimes( $count );
+		$constraint = new SpiesConstraintWasCalledTimes( $count, $this->negation );
 		if ( isset( $this->expected_args ) ) {
 			//TODO: deal with negation
 			$constraint = new SpiesConstraintWasCalledTimesWith( $count, $this->expected_args );

--- a/src/Spies/Expectation.php
+++ b/src/Spies/Expectation.php
@@ -203,8 +203,7 @@ class Expectation {
 	public function times( $count ) {
 		$constraint = new SpiesConstraintWasCalledTimes( $count, $this->negation );
 		if ( isset( $this->expected_args ) ) {
-			//TODO: deal with negation
-			$constraint = new SpiesConstraintWasCalledTimesWith( $count, $this->expected_args );
+			$constraint = new SpiesConstraintWasCalledTimesWith( $count, $this->expected_args, $this->negation );
 		}
 		$this->add_expectation_for_constraint( $constraint );
 		return $this;

--- a/src/Spies/Expectation.php
+++ b/src/Spies/Expectation.php
@@ -97,18 +97,7 @@ class Expectation {
 	 */
 	public function when( $callable ) {
 		$this->expected_function = $callable;
-		$this->delay_expectation( function() use ( $callable ) {
-			if ( $this->negation ) {
-				if ( $this->silent_failures ) {
-					return ! ( new SpiesConstraintWasCalledWhen( $callable ) )->matches( $this->spy );
-				}
-				return \Spies\TestCase::assertSpyWasNotCalledWhen( $this->spy, $callable );
-			}
-			if ( $this->silent_failures ) {
-					return ( new SpiesConstraintWasCalledWhen( $callable ) )->matches( $this->spy );
-			}
-			return \Spies\TestCase::assertSpyWasCalledWhen( $this->spy, $callable );
-		} );
+		$this->add_expectation_for_constraint( new SpiesConstraintWasCalledWhen( $this->expected_function, $this->negation ) );
 		return $this;
 	}
 

--- a/src/Spies/FailureGenerator.php
+++ b/src/Spies/FailureGenerator.php
@@ -79,4 +79,10 @@ class FailureGenerator {
 		$desc = 'with arguments matching the provided function';
 		$this->add_message( $desc );
 	}
+
+	public function spy_was_called_when( $spy ) {
+		$this->spy_was_called( $spy );
+		$desc = 'with arguments matching the provided function';
+		$this->add_message( $desc );
+	}
 }

--- a/src/Spies/FailureGenerator.php
+++ b/src/Spies/FailureGenerator.php
@@ -62,6 +62,12 @@ class FailureGenerator {
 		$this->add_message( $desc );
 	}
 
+	public function spy_was_called_before( $spy, $target_spy ) {
+		$this->spy_was_called( $spy );
+		$desc = 'before ' . $target_spy->get_function_name();
+		$this->add_message( $desc );
+	}
+
 	public function spy_was_not_called_before( $spy, $target_spy ) {
 		$this->spy_was_not_called( $spy );
 		$desc = 'before ' . $target_spy->get_function_name();

--- a/src/Spies/FailureGenerator.php
+++ b/src/Spies/FailureGenerator.php
@@ -41,6 +41,20 @@ class FailureGenerator {
 		$this->add_message( $desc );
 	}
 
+	public function spy_was_called_with_times( $spy, $args, $count ) {
+		$this->spy_was_called_with( $spy, $args );
+		$desc = $count . ' ';
+		$desc .= $count === 1 ? 'time' : 'times';
+		$this->add_message( $desc );
+	}
+
+	public function spy_was_not_called_with_times( $spy, $args, $count ) {
+		$this->spy_was_not_called_with( $spy, $args );
+		$desc = $count . ' ';
+		$desc .= $count === 1 ? 'time' : 'times';
+		$this->add_message( $desc );
+	}
+
 	public function spy_was_not_called_times( $spy, $count ) {
 		$this->spy_was_not_called( $spy );
 		$desc = $count . ' ';

--- a/src/Spies/FailureGenerator.php
+++ b/src/Spies/FailureGenerator.php
@@ -27,6 +27,13 @@ class FailureGenerator {
 		$this->add_message( $desc );
 	}
 
+	public function spy_was_called_with( $spy, $args ) {
+		$this->spy_was_called( $spy );
+		$desc = 'with ';
+		$desc .= strval( new ArgumentFormatter( $args ) );
+		$this->add_message( $desc );
+	}
+
 	public function spy_was_not_called_with_additional( $spy ) {
 		$desc = $spy->get_function_name() . ' was actually ';
 		$calls = $spy->get_called_functions();
@@ -52,5 +59,4 @@ class FailureGenerator {
 		$desc = 'with arguments matching the provided function';
 		$this->add_message( $desc );
 	}
-
 }

--- a/src/Spies/PHPUnit/ConstraintWrapper.php
+++ b/src/Spies/PHPUnit/ConstraintWrapper.php
@@ -1,0 +1,27 @@
+<?php
+namespace Spies\PHPUnit;
+
+class ConstraintWrapper extends \PHPUnit_Framework_Constraint {
+	public function __construct( $constraint ) {
+		parent::__construct();
+		$this->wrapped_constraint = $constraint;
+	}
+
+	public function matches( $other ) {
+		return $this->wrapped_constraint->matches( $other );
+	}
+
+	public function failureDescription( $other ) {
+		return $this->wrapped_constraint->failureDescription( $other );
+	}
+
+	public function additionalFailureDescription( $other ) {
+		return $this->wrapped_constraint->additionalFailureDescription( $other );
+	}
+
+	public function toString() {
+		return $this->wrapped_constraint->toString();
+	}
+}
+
+

--- a/src/Spies/SpiesConstraintWasCalled.php
+++ b/src/Spies/SpiesConstraintWasCalled.php
@@ -1,7 +1,7 @@
 <?php
 namespace Spies;
 
-class SpiesConstraintWasCalled extends \PHPUnit_Framework_Constraint {
+class SpiesConstraintWasCalled extends BaseConstraint {
 	public function matches( $other ) {
 		if ( ! $other instanceof \Spies\Spy ) {
 			return false;

--- a/src/Spies/SpiesConstraintWasCalled.php
+++ b/src/Spies/SpiesConstraintWasCalled.php
@@ -15,7 +15,7 @@ class SpiesConstraintWasCalled extends BaseConstraint {
 		return $generator->get_message();
 	}
 
-	protected function additionalFailureDescription( $other ) {
+	public function additionalFailureDescription( $other ) {
 		$generator = new FailureGenerator();
 		$generator->spy_was_not_called_with_additional( $other );
 		return $generator->get_message();

--- a/src/Spies/SpiesConstraintWasCalledBefore.php
+++ b/src/Spies/SpiesConstraintWasCalledBefore.php
@@ -5,7 +5,7 @@ class SpiesConstraintWasCalledBefore extends BaseConstraint {
 	private $target_spy;
 	private $negation;
 
-	public function __construct( $target_spy, $negation ) {
+	public function __construct( $target_spy, $negation = false ) {
 		parent::__construct();
 		$this->target_spy = $target_spy;
 		$this->negation = $negation;

--- a/src/Spies/SpiesConstraintWasCalledBefore.php
+++ b/src/Spies/SpiesConstraintWasCalledBefore.php
@@ -1,24 +1,27 @@
 <?php
 namespace Spies;
 
-class SpiesConstraintWasCalledBefore extends \PHPUnit_Framework_Constraint {
+class SpiesConstraintWasCalledBefore extends BaseConstraint {
 	private $target_spy;
+	private $negation;
 
-	public function __construct( $target_spy ) {
+	public function __construct( $target_spy, $negation ) {
 		parent::__construct();
 		$this->target_spy = $target_spy;
+		$this->negation = $negation;
 	}
 
 	public function matches( $other ) {
 		if ( ! $other instanceof \Spies\Spy ) {
 			return false;
 		}
-		return $other->was_called_before( $this->target_spy );
+		$result = $other->was_called_before( $this->target_spy );
+		return $this->negation ? ( ! $result ) : $result;
 	}
 
 	public function failureDescription( $other ) {
 		$generator = new FailureGenerator();
-		$generator->spy_was_not_called_before( $other, $this->target_spy );
+		$this->negation ? $generator->spy_was_called_before( $other, $this->target_spy ) : $generator->spy_was_not_called_before( $other, $this->target_spy );
 		return $generator->get_message();
 	}
 

--- a/src/Spies/SpiesConstraintWasCalledTimes.php
+++ b/src/Spies/SpiesConstraintWasCalledTimes.php
@@ -1,28 +1,33 @@
 <?php
 namespace Spies;
 
-class SpiesConstraintWasCalledTimes extends \PHPUnit_Framework_Constraint {
+class SpiesConstraintWasCalledTimes extends BaseConstraint {
 	private $count;
+	private $negation;
 
-	public function __construct( $count ) {
+	public function __construct( $count, $negation = false ) {
 		parent::__construct();
 		$this->count = $count;
+		$this->negation = $negation;
 	}
 
 	public function matches( $other ) {
 		if ( ! $other instanceof \Spies\Spy ) {
 			return false;
 		}
+		if ( $this->negation ) {
+			return ! $other->was_called_times( $this->count );
+		}
 		return $other->was_called_times( $this->count );
 	}
 
 	public function failureDescription( $other ) {
 		$generator = new FailureGenerator();
-		$generator->spy_was_not_called_times( $other, $this->count );
+		$this->negation ? $generator->spy_was_called_times( $other, $this->count ) : $generator->spy_was_not_called_times( $other, $this->count );
 		return $generator->get_message();
 	}
 
-	protected function additionalFailureDescription( $other ) {
+	public function additionalFailureDescription( $other ) {
 		$generator = new FailureGenerator();
 		$generator->spy_was_not_called_with_additional( $other );
 		return $generator->get_message();

--- a/src/Spies/SpiesConstraintWasCalledTimesWith.php
+++ b/src/Spies/SpiesConstraintWasCalledTimesWith.php
@@ -1,7 +1,7 @@
 <?php
 namespace Spies;
 
-class SpiesConstraintWasCalledTimesWith extends \PHPUnit_Framework_Constraint {
+class SpiesConstraintWasCalledTimesWith extends BaseConstraint {
 	private $expected_args;
 	private $count;
 
@@ -18,13 +18,13 @@ class SpiesConstraintWasCalledTimesWith extends \PHPUnit_Framework_Constraint {
 		return $other->was_called_times_with_array( $this->count, $this->expected_args );
 	}
 
-	protected function failureDescription( $other ) {
+	public function failureDescription( $other ) {
 		$generator = new FailureGenerator();
 		$generator->spy_was_not_called_with( $other, $this->expected_args );
 		return $generator->get_message();
 	}
 
-	protected function additionalFailureDescription( $other ) {
+	public function additionalFailureDescription( $other ) {
 		$generator = new FailureGenerator();
 		$generator->spy_was_not_called_with_additional( $other );
 		return $generator->get_message();

--- a/src/Spies/SpiesConstraintWasCalledTimesWith.php
+++ b/src/Spies/SpiesConstraintWasCalledTimesWith.php
@@ -4,23 +4,26 @@ namespace Spies;
 class SpiesConstraintWasCalledTimesWith extends BaseConstraint {
 	private $expected_args;
 	private $count;
+	private $negation;
 
-	public function __construct( $count, $args ) {
+	public function __construct( $count, $args, $negation = false ) {
 		parent::__construct();
 		$this->expected_args = $args;
 		$this->count = $count;
+		$this->negation = $negation;
 	}
 
 	public function matches( $other ) {
 		if ( ! $other instanceof \Spies\Spy ) {
 			return false;
 		}
-		return $other->was_called_times_with_array( $this->count, $this->expected_args );
+		$result = $other->was_called_times_with_array( $this->count, $this->expected_args );
+		return $this->negation ? ( ! $result ) : $result;
 	}
 
 	public function failureDescription( $other ) {
 		$generator = new FailureGenerator();
-		$generator->spy_was_not_called_with( $other, $this->expected_args );
+		$this->negation ? $generator->spy_was_called_with_times( $other, $this->expected_args, $this->count ) : $generator->spy_was_not_called_with_times( $other, $this->expected_args, $this->count );
 		return $generator->get_message();
 	}
 

--- a/src/Spies/SpiesConstraintWasCalledWhen.php
+++ b/src/Spies/SpiesConstraintWasCalledWhen.php
@@ -5,7 +5,7 @@ class SpiesConstraintWasCalledWhen extends BaseConstraint {
 	private $expected_callable;
 	private $negation;
 
-	public function __construct( $callable, $negation ) {
+	public function __construct( $callable, $negation = false ) {
 		parent::__construct();
 		$this->expected_callable = $callable;
 		$this->negation = $negation;

--- a/src/Spies/SpiesConstraintWasCalledWhen.php
+++ b/src/Spies/SpiesConstraintWasCalledWhen.php
@@ -1,28 +1,31 @@
 <?php
 namespace Spies;
 
-class SpiesConstraintWasCalledWhen extends \PHPUnit_Framework_Constraint {
+class SpiesConstraintWasCalledWhen extends BaseConstraint {
 	private $expected_callable;
+	private $negation;
 
-	public function __construct( $callable ) {
+	public function __construct( $callable, $negation ) {
 		parent::__construct();
 		$this->expected_callable = $callable;
+		$this->negation = $negation;
 	}
 
 	public function matches( $other ) {
 		if ( ! $other instanceof \Spies\Spy ) {
 			return false;
 		}
-		return $other->was_called_when( $this->expected_callable );
+		$result = $other->was_called_when( $this->expected_callable );
+		return $this->negation ? ( ! $result ) : $result;
 	}
 
-	protected function failureDescription( $other ) {
+	public function failureDescription( $other ) {
 		$generator = new FailureGenerator();
-		$generator->spy_was_not_called_when( $other );
+		$this->negation ? $generator->spy_was_called_when( $other ) : $generator->spy_was_not_called_when( $other );
 		return $generator->get_message();
 	}
 
-	protected function additionalFailureDescription( $other ) {
+	public function additionalFailureDescription( $other ) {
 		$generator = new FailureGenerator();
 		$generator->spy_was_not_called_with_additional( $other );
 		return $generator->get_message();

--- a/src/Spies/SpiesConstraintWasCalledWith.php
+++ b/src/Spies/SpiesConstraintWasCalledWith.php
@@ -1,7 +1,7 @@
 <?php
 namespace Spies;
 
-class SpiesConstraintWasCalledWith extends \PHPUnit_Framework_Constraint {
+class SpiesConstraintWasCalledWith extends BaseConstraint {
 	private $expected_args;
 
 	public function __construct( $args ) {
@@ -16,13 +16,13 @@ class SpiesConstraintWasCalledWith extends \PHPUnit_Framework_Constraint {
 		return $other->was_called_with_array( $this->expected_args );
 	}
 
-	protected function failureDescription( $other ) {
+	public function failureDescription( $other ) {
 		$generator = new FailureGenerator();
 		$generator->spy_was_not_called_with( $other, $this->expected_args );
 		return $generator->get_message();
 	}
 
-	protected function additionalFailureDescription( $other ) {
+	public function additionalFailureDescription( $other ) {
 		$generator = new FailureGenerator();
 		$generator->spy_was_not_called_with_additional( $other );
 		return $generator->get_message();

--- a/src/Spies/SpiesConstraintWasCalledWith.php
+++ b/src/Spies/SpiesConstraintWasCalledWith.php
@@ -3,22 +3,27 @@ namespace Spies;
 
 class SpiesConstraintWasCalledWith extends BaseConstraint {
 	private $expected_args;
+	private $negation;
 
-	public function __construct( $args ) {
+	public function __construct( $args, $negation = false ) {
 		parent::__construct();
 		$this->expected_args = $args;
+		$this->negation = $negation;
 	}
 
 	public function matches( $other ) {
 		if ( ! $other instanceof \Spies\Spy ) {
 			return false;
 		}
+		if ( $this->negation ) {
+			return ! $other->was_called_with_array( $this->expected_args );
+		}
 		return $other->was_called_with_array( $this->expected_args );
 	}
 
 	public function failureDescription( $other ) {
 		$generator = new FailureGenerator();
-		$generator->spy_was_not_called_with( $other, $this->expected_args );
+		$this->negation ?$generator->spy_was_called_with( $other, $this->expected_args ) : $generator->spy_was_not_called_with( $other, $this->expected_args );
 		return $generator->get_message();
 	}
 

--- a/src/Spies/SpiesConstraintWasNotCalled.php
+++ b/src/Spies/SpiesConstraintWasNotCalled.php
@@ -1,7 +1,7 @@
 <?php
 namespace Spies;
 
-class SpiesConstraintWasNotCalled extends \PHPUnit_Framework_Constraint {
+class SpiesConstraintWasNotCalled extends BaseConstraint {
 	public function matches( $other ) {
 		if ( ! $other instanceof \Spies\Spy ) {
 			return false;

--- a/src/Spies/TestCase.php
+++ b/src/Spies/TestCase.php
@@ -4,31 +4,31 @@ namespace Spies;
 abstract class TestCase extends \PHPUnit_Framework_TestCase {
 
 	public static function wasCalled() {
-		return new \Spies\SpiesConstraintWasCalled;
+		return new PHPUnit\ConstraintWrapper( new SpiesConstraintWasCalled() );
 	}
 
 	public static function wasNotCalled() {
-		return new \Spies\SpiesConstraintWasNotCalled;
+		return new PHPUnit\ConstraintWrapper( new SpiesConstraintWasNotCalled() );
 	}
 
 	public static function wasCalledWith( $args ) {
-		return new \Spies\SpiesConstraintWasCalledWith( $args );
+		return new PHPUnit\ConstraintWrapper( new SpiesConstraintWasCalledWith( $args ) );
 	}
 
 	public static function wasCalledTimes( $count ) {
-		return new \Spies\SpiesConstraintWasCalledTimes( $count );
+		return new PHPUnit\ConstraintWrapper( new SpiesConstraintWasCalledTimes( $count ) );
 	}
 
 	public static function wasCalledBefore( $spy ) {
-		return new \Spies\SpiesConstraintWasCalledBefore( $spy );
+		return new PHPUnit\ConstraintWrapper( new SpiesConstraintWasCalledBefore( $spy ) );
 	}
 
 	public static function wasCalledWhen( $callable ) {
-		return new \Spies\SpiesConstraintWasCalledWhen( $callable );
+		return new PHPUnit\ConstraintWrapper( new SpiesConstraintWasCalledWhen( $callable ) );
 	}
 
 	public static function wasCalledTimesWith( $count, $args ) {
-		return new \Spies\SpiesConstraintWasCalledTimesWith( $count, $args );
+		return new PHPUnit\ConstraintWrapper( new SpiesConstraintWasCalledTimesWith( $count, $args ) );
 	}
 
 	public static function assertSpyWasCalled( $condition, $message = '' ) {

--- a/src/Spies/UnmetExpectationException.php
+++ b/src/Spies/UnmetExpectationException.php
@@ -1,5 +1,10 @@
 <?php
 namespace Spies;
 
-class UnmetExpectationException extends \Exception {
+if ( class_exists( '\PHPUnit_Framework_ExpectationFailedException' ) ) {
+	class UnmetExpectationException extends \PHPUnit_Framework_ExpectationFailedException {
+	}
+} else {
+	class UnmetExpectationException extends \Exception {
+	}
 }

--- a/tests/ExpectationTest.php
+++ b/tests/ExpectationTest.php
@@ -35,6 +35,7 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 	public function test__not_to_have_been_called__reports_failure_message_on_fail() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->not->to_have_been_called();
+		$spy();
 		$this->assertEquals( 'Failed asserting that a spy is not called', $expectation->get_fail_message() );
 	}
 
@@ -66,6 +67,22 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$spy( 'foo' );
 		$spy( 'bar' );
 		$this->assertTrue( $expectation->met_expectations() );
+	}
+
+	public function test__times_with__reports_fail_message_on_fail() {
+		$spy = \Spies\make_spy();
+		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo' )->times( 2 );
+		$spy( 'bar' );
+		$this->assertEquals( 'Failed asserting that a spy is called with arguments: ( "foo" )', $expectation->get_fail_message() );
+	}
+
+	public function test__not_times_with__reports_fail_message_on_fail() {
+		$spy = \Spies\make_spy();
+		$expectation = \Spies\expect_spy( $spy )->not->to_have_been_called->with( 'foo' )->times( 2 );
+		$spy( 'foo' );
+		$spy( 'foo' );
+		$spy( 'bar' );
+		$this->assertEquals( 'Failed asserting that a spy is not called with arguments: ( "foo" )', $expectation->get_fail_message() );
 	}
 
 	public function test__times__is_not_met_if_spy_is_not_called() {

--- a/tests/ExpectationTest.php
+++ b/tests/ExpectationTest.php
@@ -195,6 +195,24 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue( $expectation->met_expectations() );
 	}
 
+	public function test__when__reports_failure_message_on_fail() {
+		$spy = \Spies\make_spy();
+		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->when( function() {
+			return false;
+		} );
+		$spy( 'foo', 'bar' );
+		$this->assertEquals( 'Failed asserting that a function was called with arguments matching the provided function', $expectation->get_fail_message() );
+	}
+
+	public function test__not_when__reports_failure_message_on_fail() {
+		$spy = \Spies\make_spy();
+		$expectation = \Spies\expect_spy( $spy )->not->to_have_been_called->when( function() {
+			return true;
+		} );
+		$spy( 'foo', 'bar' );
+		$this->assertEquals( 'Failed asserting that a function was not called with arguments matching the provided function', $expectation->get_fail_message() );
+	}
+
 	public function test__when__function_receives_arguments_for_each_call() {
 		$found = [];
 		$spy = \Spies\make_spy();

--- a/tests/ExpectationTest.php
+++ b/tests/ExpectationTest.php
@@ -349,6 +349,15 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue( $expectation->met_expectations() );
 	}
 
+	public function test__before__reports_failure_message_on_fail() {
+		$spy_1 = \Spies\make_spy();
+		$spy_2 = \Spies\make_spy();
+		$expectation = \Spies\expect_spy( $spy_1 )->to_have_been_called->before( $spy_2 );
+		$spy_2( 'bar' );
+		$spy_1( 'foo' );
+		$this->assertEquals( 'Failed asserting that a spy is called before a spy', $expectation->get_fail_message() );
+	}
+
 	public function test__before__is_not_met_if_the_spy_was_called_after_another_spy() {
 		$spy_1 = \Spies\make_spy();
 		$spy_2 = \Spies\make_spy();
@@ -356,6 +365,15 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$spy_2( 'bar' );
 		$spy_1( 'foo' );
 		$this->assertFalse( $expectation->met_expectations() );
+	}
+
+	public function test__not_before__reports_failure_message_on_fail() {
+		$spy_1 = \Spies\make_spy();
+		$spy_2 = \Spies\make_spy();
+		$expectation = \Spies\expect_spy( $spy_1 )->not->to_have_been_called->before( $spy_2 );
+		$spy_1( 'foo' );
+		$spy_2( 'bar' );
+		$this->assertEquals( 'Failed asserting that a spy is not called before a spy', $expectation->get_fail_message() );
 	}
 
 	public function test_global_expectation_is_cleared_by_finish_spying() {

--- a/tests/ExpectationTest.php
+++ b/tests/ExpectationTest.php
@@ -24,8 +24,13 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function test__verify__throws_exception_on_fail() {
-		// TODO: this will be the exception outside of PHPUnit; we need to be able to test both
-		// $this->expectException( \Spies\UnmetExpectationException::class );
+		$this->expectException( \Spies\UnmetExpectationException::class );
+		$spy = \Spies\make_spy();
+		$expectation = \Spies\expect_spy( $spy )->to_have_been_called();
+		$expectation->verify();
+	}
+
+	public function test__verify__throws_phpunit_exception_on_fail() {
 		$this->expectException( \PHPUnit_Framework_ExpectationFailedException::class );
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called();

--- a/tests/ExpectationTest.php
+++ b/tests/ExpectationTest.php
@@ -1,8 +1,5 @@
 <?php
 
-/**
- * @runTestsInSeparateProcesses
- */
 class ExpectationTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown() {
@@ -27,7 +24,9 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function test__verify__throws_exception_on_fail() {
-		$this->expectException( \Spies\UnmetExpectationException::class );
+		// TODO: this will be the exception outside of PHPUnit; we need to be able to test both
+		// $this->expectException( \Spies\UnmetExpectationException::class );
+		$this->expectException( \PHPUnit_Framework_ExpectationFailedException::class );
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called();
 		$expectation->verify();
@@ -36,14 +35,14 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 	public function test__to_have_been_called__reports_failure_message_on_fail() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called();
-		$this->assertEquals( 'Failed asserting that a spy is called', $expectation->get_fail_message() );
+		$this->assertContains( 'Failed asserting that a spy is called', $expectation->get_fail_message() );
 	}
 
 	public function test__not_to_have_been_called__reports_failure_message_on_fail() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->not->to_have_been_called();
 		$spy();
-		$this->assertEquals( 'Failed asserting that a spy is not called', $expectation->get_fail_message() );
+		$this->assertContains( 'Failed asserting that a spy is not called', $expectation->get_fail_message() );
 	}
 
 	public function test__to_have_been_called__is_met_if_spy_was_called() {
@@ -80,7 +79,7 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo' );
 		$spy( 'bar' );
-		$this->assertEquals( 'Failed asserting that a spy is called with arguments: ( "foo" )', $expectation->get_fail_message() );
+		$this->assertContains( 'Failed asserting that a spy is called with arguments: ( "foo" )', $expectation->get_fail_message() );
 	}
 
 	public function test__times_with__reports_fail_message_on_fail() {
@@ -88,7 +87,7 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo' )->times( 2 );
 		$spy( 'foo' );
 		$spy( 'bar' );
-		$this->assertEquals( 'Failed asserting that a spy is called with arguments: ( "foo" ) 2 times', $expectation->get_fail_message() );
+		$this->assertContains( 'Failed asserting that a spy is called with arguments: ( "foo" ) 2 times', $expectation->get_fail_message() );
 	}
 
 	public function test__not_with__reports_fail_message_on_fail() {
@@ -96,7 +95,7 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$expectation = \Spies\expect_spy( $spy )->not->to_have_been_called->with( 'foo' );
 		$spy( 'foo' );
 		$spy( 'bar' );
-		$this->assertEquals( 'Failed asserting that a spy is not called with arguments: ( "foo" )', $expectation->get_fail_message() );
+		$this->assertContains( 'Failed asserting that a spy is not called with arguments: ( "foo" )', $expectation->get_fail_message() );
 	}
 
 	public function test__not_times_with__reports_fail_message_on_fail() {
@@ -105,7 +104,7 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$spy( 'foo' );
 		$spy( 'foo' );
 		$spy( 'bar' );
-		$this->assertEquals( 'Failed asserting that a spy is not called with arguments: ( "foo" )', $expectation->get_fail_message() );
+		$this->assertContains( 'Failed asserting that a spy is not called with arguments: ( "foo" )', $expectation->get_fail_message() );
 	}
 
 	public function test__times__is_not_met_if_spy_is_not_called() {
@@ -201,7 +200,7 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 			return false;
 		} );
 		$spy( 'foo', 'bar' );
-		$this->assertEquals( 'Failed asserting that a spy is called with arguments matching the provided function', $expectation->get_fail_message() );
+		$this->assertContains( 'Failed asserting that a spy is called with arguments matching the provided function', $expectation->get_fail_message() );
 	}
 
 	public function test__not_when__reports_failure_message_on_fail() {
@@ -210,7 +209,7 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 			return true;
 		} );
 		$spy( 'foo', 'bar' );
-		$this->assertEquals( 'Failed asserting that a spy is not called with arguments matching the provided function', $expectation->get_fail_message() );
+		$this->assertContains( 'Failed asserting that a spy is not called with arguments matching the provided function', $expectation->get_fail_message() );
 	}
 
 	public function test__when__function_receives_arguments_for_each_call() {
@@ -373,7 +372,7 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$expectation = \Spies\expect_spy( $spy_1 )->to_have_been_called->before( $spy_2 );
 		$spy_2( 'bar' );
 		$spy_1( 'foo' );
-		$this->assertEquals( 'Failed asserting that a spy is called before a spy', $expectation->get_fail_message() );
+		$this->assertContains( 'Failed asserting that a spy is called before a spy', $expectation->get_fail_message() );
 	}
 
 	public function test__before__is_not_met_if_the_spy_was_called_after_another_spy() {
@@ -391,7 +390,7 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$expectation = \Spies\expect_spy( $spy_1 )->not->to_have_been_called->before( $spy_2 );
 		$spy_1( 'foo' );
 		$spy_2( 'bar' );
-		$this->assertEquals( 'Failed asserting that a spy is not called before a spy', $expectation->get_fail_message() );
+		$this->assertContains( 'Failed asserting that a spy is not called before a spy', $expectation->get_fail_message() );
 	}
 
 	public function test_global_expectation_is_cleared_by_finish_spying() {

--- a/tests/ExpectationTest.php
+++ b/tests/ExpectationTest.php
@@ -9,35 +9,40 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		\Spies\finish_spying();
 	}
 
-	public function test_expect_spy_throws_an_error_if_called_without_a_spy() {
+	public function test__expect_spy__throws_an_error_if_called_without_a_spy() {
 		$this->expectException( InvalidArgumentException::class );
 		\Spies\expect_spy( 'foobar' );
 	}
 
-	public function test_expect_spy_returns_an_expectation() {
+	public function test__expect_spy__returns_an_expectation() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy );
 		$this->assertTrue( $expectation instanceof \Spies\Expectation );
 	}
 
-	public function test_to_have_been_called_is_not_met_if_spy_was_not_called() {
+	public function test__to_have_been_called__is_not_met_if_spy_was_not_called() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called();
-		$expectation->silent_failures = true;
-		$this->assertFalse( $expectation->verify() );
+		$this->assertFalse( $expectation->met_expectations() );
 	}
 
-	public function test_to_have_been_called_is_met_if_spy_was_called() {
+	public function test__to_have_been_called__reports_failure_message_on_fail() {
+		$spy = \Spies\make_spy();
+		$expectation = \Spies\expect_spy( $spy )->to_have_been_called();
+		$this->assertEquals( 'Failed asserting that a spy is called', $expectation->get_fail_message() );
+	}
+
+	public function test__to_have_been_called__is_met_if_spy_was_called() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called();
 		$spy();
-		$expectation->verify();
+		$this->assertTrue( $expectation->met_expectations() );
 	}
 
-	public function test_not_reverses_the_expectation() {
+	public function test__not__reverses_an_expectation() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->not->to_have_been_called();
-		$expectation->verify();
+		$this->assertTrue( $expectation->met_expectations() );
 	}
 
 	public function test_times_is_met_if_spy_is_called_that_many_times() {

--- a/tests/ExpectationTest.php
+++ b/tests/ExpectationTest.php
@@ -81,7 +81,7 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo' )->times( 2 );
 		$spy( 'foo' );
 		$spy( 'bar' );
-		$this->assertEquals( 'Failed asserting that a spy is called with arguments: ( "foo" )', $expectation->get_fail_message() );
+		$this->assertEquals( 'Failed asserting that a spy is called with arguments: ( "foo" ) 2 times', $expectation->get_fail_message() );
 	}
 
 	public function test__not_with__reports_fail_message_on_fail() {
@@ -98,7 +98,7 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$spy( 'foo' );
 		$spy( 'foo' );
 		$spy( 'bar' );
-		$this->assertEquals( 'Failed asserting that a spy is not called with arguments: ( "foo" ) 2 times', $expectation->get_fail_message() );
+		$this->assertEquals( 'Failed asserting that a spy is not called with arguments: ( "foo" )', $expectation->get_fail_message() );
 	}
 
 	public function test__times__is_not_met_if_spy_is_not_called() {

--- a/tests/ExpectationTest.php
+++ b/tests/ExpectationTest.php
@@ -201,7 +201,7 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 			return false;
 		} );
 		$spy( 'foo', 'bar' );
-		$this->assertEquals( 'Failed asserting that a function was called with arguments matching the provided function', $expectation->get_fail_message() );
+		$this->assertEquals( 'Failed asserting that a spy is called with arguments matching the provided function', $expectation->get_fail_message() );
 	}
 
 	public function test__not_when__reports_failure_message_on_fail() {
@@ -210,7 +210,7 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 			return true;
 		} );
 		$spy( 'foo', 'bar' );
-		$this->assertEquals( 'Failed asserting that a function was not called with arguments matching the provided function', $expectation->get_fail_message() );
+		$this->assertEquals( 'Failed asserting that a spy is not called with arguments matching the provided function', $expectation->get_fail_message() );
 	}
 
 	public function test__when__function_receives_arguments_for_each_call() {

--- a/tests/ExpectationTest.php
+++ b/tests/ExpectationTest.php
@@ -26,6 +26,13 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse( $expectation->met_expectations() );
 	}
 
+	public function test__verify__throws_exception_on_fail() {
+		$this->expectException( \Spies\UnmetExpectationException::class );
+		$spy = \Spies\make_spy();
+		$expectation = \Spies\expect_spy( $spy )->to_have_been_called();
+		$expectation->verify();
+	}
+
 	public function test__to_have_been_called__reports_failure_message_on_fail() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called();

--- a/tests/ExpectationTest.php
+++ b/tests/ExpectationTest.php
@@ -69,11 +69,27 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue( $expectation->met_expectations() );
 	}
 
+	public function test__with__reports_fail_message_on_fail() {
+		$spy = \Spies\make_spy();
+		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo' );
+		$spy( 'bar' );
+		$this->assertEquals( 'Failed asserting that a spy is called with arguments: ( "foo" )', $expectation->get_fail_message() );
+	}
+
 	public function test__times_with__reports_fail_message_on_fail() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo' )->times( 2 );
+		$spy( 'foo' );
 		$spy( 'bar' );
 		$this->assertEquals( 'Failed asserting that a spy is called with arguments: ( "foo" )', $expectation->get_fail_message() );
+	}
+
+	public function test__not_with__reports_fail_message_on_fail() {
+		$spy = \Spies\make_spy();
+		$expectation = \Spies\expect_spy( $spy )->not->to_have_been_called->with( 'foo' );
+		$spy( 'foo' );
+		$spy( 'bar' );
+		$this->assertEquals( 'Failed asserting that a spy is not called with arguments: ( "foo" )', $expectation->get_fail_message() );
 	}
 
 	public function test__not_times_with__reports_fail_message_on_fail() {
@@ -82,7 +98,7 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$spy( 'foo' );
 		$spy( 'foo' );
 		$spy( 'bar' );
-		$this->assertEquals( 'Failed asserting that a spy is not called with arguments: ( "foo" )', $expectation->get_fail_message() );
+		$this->assertEquals( 'Failed asserting that a spy is not called with arguments: ( "foo" ) 2 times', $expectation->get_fail_message() );
 	}
 
 	public function test__times__is_not_met_if_spy_is_not_called() {

--- a/tests/ExpectationTest.php
+++ b/tests/ExpectationTest.php
@@ -32,6 +32,12 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 'Failed asserting that a spy is called', $expectation->get_fail_message() );
 	}
 
+	public function test__not_to_have_been_called__reports_failure_message_on_fail() {
+		$spy = \Spies\make_spy();
+		$expectation = \Spies\expect_spy( $spy )->not->to_have_been_called();
+		$this->assertEquals( 'Failed asserting that a spy is not called', $expectation->get_fail_message() );
+	}
+
 	public function test__to_have_been_called__is_met_if_spy_was_called() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called();

--- a/tests/ExpectationTest.php
+++ b/tests/ExpectationTest.php
@@ -45,117 +45,111 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue( $expectation->met_expectations() );
 	}
 
-	public function test_times_is_met_if_spy_is_called_that_many_times() {
+	public function test__times__is_met_if_spy_is_called_that_many_times() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->times( 2 );
 		$spy();
 		$spy();
-		$expectation->verify();
+		$this->assertTrue( $expectation->met_expectations() );
 	}
 
-	public function test_times_is_met_if_following_with() {
+	public function test__times__is_met_if_following__with() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo' )->times( 2 );
 		$spy( 'foo' );
 		$spy( 'foo' );
 		$spy( 'bar' );
-		$expectation->verify();
+		$this->assertTrue( $expectation->met_expectations() );
 	}
 
-	public function test_times_is_not_met_if_spy_is_not_called() {
+	public function test__times__is_not_met_if_spy_is_not_called() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->times( 2 );
-		$expectation->silent_failures = true;
-		$this->assertFalse( $expectation->verify() );
+		$this->assertFalse( $expectation->met_expectations() );
 	}
 
-	public function test_times_is_not_met_if_spy_is_called_more_than_that_many_times() {
+	public function test__times__is_not_met_if_spy_is_called_more_than_that_many_times() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->times( 2 );
-		$expectation->silent_failures = true;
 		$spy();
 		$spy();
 		$spy();
-		$this->assertFalse( $expectation->verify() );
+		$this->assertFalse( $expectation->met_expectations() );
 	}
 
-	public function test_once_as_property_throws_an_error() {
+	public function test__once__as_property_throws_an_error() {
 		$this->expectException( \Spies\InvalidExpectationException::class );
 		$spy = \Spies\make_spy();
 		\Spies\expect_spy( $spy )->to_have_been_called->once;
 	}
 
-	public function test_once_is_met_if_spy_is_called_once() {
+	public function test__once__is_met_if_spy_is_called_once() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->once();
 		$spy();
-		$expectation->verify();
+		$this->assertTrue( $expectation->met_expectations() );
 	}
 
-	public function test_once_is_not_met_if_spy_is_not_called() {
+	public function test__once__is_not_met_if_spy_is_not_called() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->once();
-		$expectation->silent_failures = true;
-		$this->assertFalse( $expectation->verify() );
+		$this->assertFalse( $expectation->met_expectations() );
 	}
 
-	public function test_twice_as_property_throws_an_error() {
+	public function test__twice__as_property_throws_an_error() {
 		$this->expectException( \Spies\InvalidExpectationException::class );
 		$spy = \Spies\make_spy();
 		\Spies\expect_spy( $spy )->to_have_been_called->twice;
 	}
 
-	public function test_once_is_not_met_if_spy_is_called_twice() {
+	public function test__once__is_not_met_if_spy_is_called_twice() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->once();
-		$expectation->silent_failures = true;
 		$spy();
 		$spy();
-		$this->assertFalse( $expectation->verify() );
+		$this->assertFalse( $expectation->met_expectations() );
 	}
 
-	public function test_twice_is_met_if_spy_is_called_twice() {
+	public function test__twice__is_met_if_spy_is_called_twice() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->twice();
 		$spy();
 		$spy();
-		$expectation->verify();
+		$this->assertTrue( $expectation->met_expectations() );
 	}
 
-	public function test_twice_is_not_met_if_spy_is_not_called() {
+	public function test__twice__is_not_met_if_spy_is_not_called() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->twice();
-		$expectation->silent_failures = true;
-		$this->assertFalse( $expectation->verify() );
+		$this->assertFalse( $expectation->met_expectations() );
 	}
 
-	public function test_twice_is_not_met_if_spy_is_called_thrice() {
+	public function test__twice__is_not_met_if_spy_is_called_thrice() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->twice();
-		$expectation->silent_failures = true;
 		$spy();
 		$spy();
 		$spy();
-		$this->assertFalse( $expectation->verify() );
+		$this->assertFalse( $expectation->met_expectations() );
 	}
 
-	public function test_with_is_met_if_the_spy_is_called_with_the_same_arguments() {
+	public function test__with__is_met_if_the_spy_is_called_with_the_same_arguments() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', 'bar' );
 		$spy( 'foo', 'bar' );
-		$expectation->verify();
+		$this->assertTrue( $expectation->met_expectations() );
 	}
 
-	public function test_when_is_met_if_the_spy_is_called_and_function_returns_true() {
+	public function test__when__is_met_if_the_spy_is_called_and_function_returns_true() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->when( function() {
 			return true;
 		} );
 		$spy( 'foo', 'bar' );
-		$expectation->verify();
+		$this->assertTrue( $expectation->met_expectations() );
 	}
 
-	public function test_when_function_receives_arguments_for_each_call() {
+	public function test__when__function_receives_arguments_for_each_call() {
 		$found = [];
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->when( function( $args ) use ( &$found ) {
@@ -164,31 +158,30 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		} );
 		$spy( 'foo', 'bar' );
 		$spy( 'boo', 'far' );
-		$expectation->verify();
+		$this->assertTrue( $expectation->met_expectations() );
 		$this->assertEquals( [ 'foo', 'bar' ], $found[0] );
 		$this->assertEquals( [ 'boo', 'far' ], $found[1] );
 	}
 
-	public function test_when_is_not_met_if_the_spy_is_called_and_function_returns_false() {
+	public function test__when__is_not_met_if_the_spy_is_called_and_function_returns_false() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->when( function() {
 			return false;
 		} );
-		$expectation->silent_failures = true;
 		$spy( 'foo', 'bar' );
-		$this->assertFalse( $expectation->verify() );
+		$this->assertFalse( $expectation->met_expectations() );
 	}
 
-	public function test_with_is_met_if_the_spy_is_called_and_function_returns_true() {
+	public function test__with__is_met_if_the_spy_is_called_and_function_returns_true() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( function() {
 			return true;
 		} );
 		$spy( 'foo', 'bar' );
-		$expectation->verify();
+		$this->assertTrue( $expectation->met_expectations() );
 	}
 
-	public function test_with_function_receives_arguments_for_each_call() {
+	public function test__with__function_receives_arguments_for_each_call() {
 		$found = [];
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( function( $args ) use ( &$found ) {
@@ -197,135 +190,126 @@ class ExpectationTest extends PHPUnit_Framework_TestCase {
 		} );
 		$spy( 'foo', 'bar' );
 		$spy( 'boo', 'far' );
-		$expectation->verify();
+		$this->assertTrue( $expectation->met_expectations() );
 		$this->assertEquals( [ 'foo', 'bar' ], $found[0] );
 		$this->assertEquals( [ 'boo', 'far' ], $found[1] );
 	}
 
-	public function test_with_is_not_met_if_the_spy_is_called_and_function_returns_false() {
+	public function test__with__is_not_met_if_the_spy_is_called_and_function_returns_false() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( function() {
 			return false;
 		} );
-		$expectation->silent_failures = true;
 		$spy( 'foo', 'bar' );
-		$this->assertFalse( $expectation->verify() );
+		$this->assertFalse( $expectation->met_expectations() );
 	}
 
-	public function test_with_match_pattern_is_met_if_the_spy_is_called_with_matching_pattern() {
+	public function test__with__and__match_pattern__is_met_if_the_spy_is_called_with_matching_pattern() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', \Spies\match_pattern( '/Bart/i' ) );
 		$spy( 'foo', 'slartibartfast' );
-		$expectation->verify();
+		$this->assertTrue( $expectation->met_expectations() );
 	}
 
-	public function test_with_match_pattern_is_not_met_if_the_spy_is_called_with_differing_pattern() {
+	public function test__with__and__match_pattern__is_not_met_if_the_spy_is_called_with_differing_pattern() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', \Spies\match_pattern( '/Bart/i' ) );
-		$expectation->silent_failures = true;
 		$spy( 'foo', 'slartiblargfast' );
-		$this->assertFalse( $expectation->verify() );
+		$this->assertFalse( $expectation->met_expectations() );
 	}
 
-	public function test_with_match_array_is_met_if_the_spy_is_called_with_matching_key_values() {
+	public function test__with__and__match_array__is_met_if_the_spy_is_called_with_matching_key_values() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', \Spies\match_array( [ 'foo' => 'bar', 'flim' => 'flam' ] ) );
 		$spy( 'foo', [ 'bar' => 'baz', 'foo' => 'bar', 'flim' => 'flam' ] );
-		$expectation->verify();
+		$this->assertTrue( $expectation->met_expectations() );
 	}
 
-	public function test_with_match_array_is_met_if_the_spy_is_called_with_matching_key_values_for_exact_match() {
+	public function test__with__and__match_array__is_met_if_the_spy_is_called_with_matching_key_values_for_exact_match() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', \Spies\match_array( [ 'foo' => 'bar' ] ) );
 		$spy( 'foo', [ 'foo' => 'bar' ] );
-		$expectation->verify();
+		$this->assertTrue( $expectation->met_expectations() );
 	}
 
-	public function test_with_match_array_is_met_if_the_spy_is_called_with_matching_index_keys() {
+	public function test__with__and__match_array__is_met_if_the_spy_is_called_with_matching_index_keys() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', \Spies\match_array( [ 'bar', 'foo' ] ) );
 		$spy( 'foo', [ 'foo', 'bar', 'baz' ] );
-		$expectation->verify();
+		$this->assertTrue( $expectation->met_expectations() );
 	}
 
-	public function test_with_match_array_is_met_if_the_spy_is_called_with_matching_index_keys_for_exact_match() {
+	public function test__with__and__match_array__is_met_if_the_spy_is_called_with_matching_index_keys_for_exact_match() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', \Spies\match_array( [ 'bar', 'foo' ] ) );
 		$spy( 'foo', [ 'bar', 'foo' ] );
-		$expectation->verify();
+		$this->assertTrue( $expectation->met_expectations() );
 	}
 
-	public function test_with_match_array_is_not_met_if_the_spy_is_called_with_no_matching_index_keys() {
+	public function test__with__and__match_array__is_not_met_if_the_spy_is_called_with_no_matching_index_keys() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', \Spies\match_array( [ 'beep' ] ) );
-		$expectation->silent_failures = true;
 		$spy( 'foo', [ 'foo', 'bar', 'baz' ] );
-		$this->assertFalse( $expectation->verify() );
+		$this->assertFalse( $expectation->met_expectations() );
 	}
 
-	public function test_with_match_array_is_not_met_if_the_spy_is_called_with_no_matching_key_values() {
+	public function test__with__and__match_array__is_not_met_if_the_spy_is_called_with_no_matching_key_values() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', \Spies\match_array( [ 'foo' => 'baz' ] ) );
-		$expectation->silent_failures = true;
 		$spy( 'foo', [ 'bar' => 'baz', 'foo' => 'bar', 'flim' => 'flam' ] );
-		$this->assertFalse( $expectation->verify() );
+		$this->assertFalse( $expectation->met_expectations() );
 	}
 
-	public function test_with_match_array_is_not_met_if_the_spy_is_called_with_some_matching_key_values() {
+	public function test__with__and__match_array__is_not_met_if_the_spy_is_called_with_some_matching_key_values() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', \Spies\match_array( [ 'foo' => 'baz', 'flim' => 'flam' ] ) );
-		$expectation->silent_failures = true;
 		$spy( 'foo', [ 'bar' => 'baz', 'foo' => 'bar', 'flim' => 'flam' ] );
-		$this->assertFalse( $expectation->verify() );
+		$this->assertFalse( $expectation->met_expectations() );
 	}
 
-	public function test_with_any_is_met_if_the_spy_is_called_with_any_arguments() {
+	public function test__with__and__any__is_met_if_the_spy_is_called_with_any_arguments() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', \Spies\any() );
 		$spy( 'foo', 'bar' );
-		$expectation->verify();
+		$this->assertTrue( $expectation->met_expectations() );
 	}
 
-	public function test_with_is_not_met_if_the_spy_is_called_with_no_arguments() {
+	public function test__with__is_not_met_if_the_spy_is_called_with_no_arguments() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', 'bar' );
-		$expectation->silent_failures = true;
 		$spy();
-		$this->assertFalse( $expectation->verify() );
+		$this->assertFalse( $expectation->met_expectations() );
 	}
 
-	public function test_with_is_not_met_if_the_spy_is_called_with_different_arguments() {
+	public function test__with__is_not_met_if_the_spy_is_called_with_different_arguments() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', 'bar' );
-		$expectation->silent_failures = true;
 		$spy( 'foo' );
-		$this->assertFalse( $expectation->verify() );
+		$this->assertFalse( $expectation->met_expectations() );
 	}
 
-	public function test_with_is_not_met_if_the_spy_is_not_called() {
+	public function test__with__is_not_met_if_the_spy_is_not_called() {
 		$spy = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy )->to_have_been_called->with( 'foo', 'bar' );
-		$expectation->silent_failures = true;
-		$this->assertFalse( $expectation->verify() );
+		$this->assertFalse( $expectation->met_expectations() );
 	}
 
-	public function test_before_is_met_if_the_spy_was_called_before_another_spy() {
+	public function test__before__is_met_if_the_spy_was_called_before_another_spy() {
 		$spy_1 = \Spies\make_spy();
 		$spy_2 = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy_1 )->to_have_been_called->before( $spy_2 );
 		$spy_1( 'foo' );
 		$spy_2( 'bar' );
-		$expectation->verify();
+		$this->assertTrue( $expectation->met_expectations() );
 	}
 
-	public function test_before_is_not_met_if_the_spy_was_called_after_another_spy() {
+	public function test__before__is_not_met_if_the_spy_was_called_after_another_spy() {
 		$spy_1 = \Spies\make_spy();
 		$spy_2 = \Spies\make_spy();
 		$expectation = \Spies\expect_spy( $spy_1 )->to_have_been_called->before( $spy_2 );
 		$spy_2( 'bar' );
 		$spy_1( 'foo' );
-		$expectation->silent_failures = true;
-		$this->assertFalse( $expectation->verify() );
+		$this->assertFalse( $expectation->met_expectations() );
 	}
 
 	public function test_global_expectation_is_cleared_by_finish_spying() {


### PR DESCRIPTION
This is a big refactor of Expectations so that they do not rely on PHPUnit.

It greatly simplifies the code that adds expected behaviors, and adds the new methods, `Expectation->met_expectations()` and `Expectation->get_fail_message()`. These are helpful methods in general and also make it much easier to test Spies without keeping extra state variables like `$silent_failures`.

The important `Expectation->verify()` method remains, but now simply throws an exception if `get_fail_message()` returns a non-null value. If PHPUnit is loaded, the exception thrown will be an instance of `PHPUnit_Framework_ExpectationFailedException` so that it is treated correctly by the runner.

Constraints are kept in their PHPUnit form, but they are modified to inherit from a `Spies` class instead (`BaseConstraint`), and they retain no connection to PHPUnit. To use them in PHPUnit custom assertions, we wrap them in an instance of `Spies\PHPUnit\ConstraintWrapper`, which delegates method calls to the underlying Constraint instance.

Part of #22 
