### PR TITLE
Fix/infinite loop on restub invoke

### DIFF
--- a/src/Spies/GlobalSpies.php
+++ b/src/Spies/GlobalSpies.php
@@ -111,7 +111,7 @@ class GlobalSpies {
 		}
 
 		// skip if the function did not exist before (i.e. had no "original" function)
-		if ( isset( self::$generated_functions[ $function_name ] )) {
+		if ( isset( self::$generated_functions[ $function_name ] ) ) {
 			return;
 		}
 

--- a/tests/ConsecutiveExecutionTest.php
+++ b/tests/ConsecutiveExecutionTest.php
@@ -1,0 +1,41 @@
+<?php
+
+
+function bar() {
+	return - 1;
+}
+
+
+class ConsecutiveExecutionTest extends \Spies\TestCase {
+	function tearDown() {
+		\Spies\finish_spying();
+	}
+
+	public function test_global_function_can_be_stubbed() {
+		$bar_spy = \Spies\get_spy_for( 'bar' )->and_return( 0 );
+		$ret     = bar();
+		$this->assertEquals( 1, $bar_spy->get_times_called() );
+		$this->assertEquals( 0, $ret );
+	}
+
+	public function test_global_function_can_be_restubbed() {
+		$bar_spy = \Spies\get_spy_for( 'bar' );
+		$ret     = bar();
+		$this->assertEquals( 1, $bar_spy->get_times_called() );
+		$this->assertEquals( - 1, $ret );
+	}
+
+	public function test_global_function_can_be_restubbed_again() {
+		$bar_spy = \Spies\get_spy_for( 'bar' );
+		$ret     = bar();
+		$this->assertEquals( 1, $bar_spy->get_times_called() );
+		$this->assertEquals( - 1, $ret );
+	}
+
+	public function test_global_function_can_be_restubbed_again_with_new_return() {
+		$bar_spy = \Spies\get_spy_for( 'bar' )->and_return( 3 );
+		$ret     = bar();
+		$this->assertEquals( 1, $bar_spy->get_times_called() );
+		$this->assertEquals( 3, $ret );
+	}
+}

--- a/tests/ConsecutiveExecutionTest.php
+++ b/tests/ConsecutiveExecutionTest.php
@@ -1,40 +1,67 @@
 <?php
 
 
-function bar() {
+function global_function_bar() {
 	return - 1;
 }
-
 
 class ConsecutiveExecutionTest extends \Spies\TestCase {
 	function tearDown() {
 		\Spies\finish_spying();
 	}
 
-	public function test_global_function_can_be_stubbed() {
-		$bar_spy = \Spies\get_spy_for( 'bar' )->and_return( 0 );
-		$ret     = bar();
+	public function test__undefined_function___can_be_stubbed() {
+		$foo_spy = \Spies\get_spy_for( 'undefined_function' )->and_return( 4 );
+		$ret     = undefined_function();
+		$this->assertEquals( 1, $foo_spy->get_times_called() );
+		$this->assertEquals( 4, $ret );
+	}
+
+	public function test__undefined_function___can_be_restubbed() {
+		$foo_spy = \Spies\get_spy_for( 'undefined_function' );
+		$ret     = undefined_function();
+		$this->assertEquals( 1, $foo_spy->get_times_called() );
+		$this->assertEquals( null, $ret );
+	}
+
+	public function test__undefined_function___can_be_restubbed_again() {
+		$foo_spy = \Spies\get_spy_for( 'undefined_function' );
+		$ret     = undefined_function();
+		$this->assertEquals( 1, $foo_spy->get_times_called() );
+		$this->assertEquals( null, $ret );
+	}
+
+	public function test__undefined_function___can_be_restubbed_again_with_new_return() {
+		$foo_spy = \Spies\get_spy_for( 'undefined_function' )->and_return( 3 );
+		$ret     = undefined_function();
+		$this->assertEquals( 1, $foo_spy->get_times_called() );
+		$this->assertEquals( 3, $ret );
+	}
+
+	public function test__global_function__can_be_stubbed() {
+		$bar_spy = \Spies\get_spy_for( 'global_function_bar' )->and_return( 0 );
+		$ret     = global_function_bar();
 		$this->assertEquals( 1, $bar_spy->get_times_called() );
 		$this->assertEquals( 0, $ret );
 	}
 
-	public function test_global_function_can_be_restubbed() {
-		$bar_spy = \Spies\get_spy_for( 'bar' );
-		$ret     = bar();
+	public function test__global_function__can_be_restubbed() {
+		$bar_spy = \Spies\get_spy_for( 'global_function_bar' );
+		$ret     = global_function_bar();
 		$this->assertEquals( 1, $bar_spy->get_times_called() );
 		$this->assertEquals( - 1, $ret );
 	}
 
-	public function test_global_function_can_be_restubbed_again() {
-		$bar_spy = \Spies\get_spy_for( 'bar' );
-		$ret     = bar();
+	public function test__global_function__can_be_restubbed_again() {
+		$bar_spy = \Spies\get_spy_for( 'global_function_bar' );
+		$ret     = global_function_bar();
 		$this->assertEquals( 1, $bar_spy->get_times_called() );
 		$this->assertEquals( - 1, $ret );
 	}
 
-	public function test_global_function_can_be_restubbed_again_with_new_return() {
-		$bar_spy = \Spies\get_spy_for( 'bar' )->and_return( 3 );
-		$ret     = bar();
+	public function test__global_function__can_be_restubbed_again_with_new_return() {
+		$bar_spy = \Spies\get_spy_for( 'global_function_bar' )->and_return( 3 );
+		$ret     = global_function_bar();
 		$this->assertEquals( 1, $bar_spy->get_times_called() );
 		$this->assertEquals( 3, $ret );
 	}


### PR DESCRIPTION
Fixes https://github.com/sirbrillig/spies/issues/31

(I know this repo has not been developed in long time but your feedback is appreciated. :smile: )

The first commit adds tests for https://github.com/sirbrillig/spies/pull/28, to make sure there is no regression.

The second and third commit respectively tests and fixes the problem described in https://github.com/sirbrillig/spies/issues/31.

Without the change in the third commit, the tests would get stuck in the infinite loop or cause `Allowed Memory Exhausted` error.

### Testing instructions
Please run tests with a memory limit (i.e. `vendor/bin/phpunit -d memory_limit=24M`) so that tests are not stuck in a loop for a long time.

<details>
  <summary>Apply this patch (to remove @runTestsInSeparateProcesses and add finish_spying)</summary>
  
  ```
  Index: tests/StubTest.php
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/tests/StubTest.php b/tests/StubTest.php
--- a/tests/StubTest.php	
+++ b/tests/StubTest.php	
@@ -1,9 +1,11 @@
 <?php
 
-/**
- * @runTestsInSeparateProcesses
- */
+
 class StubTest extends PHPUnit_Framework_TestCase {
+	public function tearDown() {
+		\Spies\finish_spying();
+	}
+
 	public function test_mock_function_returns_a_spy() {
 		$stub = \Spies\mock_function( 'test_stub' );
 		$this->assertTrue( $stub instanceof \Spies\Spy );
Index: tests/SpyTest.php
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/tests/SpyTest.php b/tests/SpyTest.php
--- a/tests/SpyTest.php	
+++ b/tests/SpyTest.php	
@@ -7,10 +7,12 @@
 	return $val;
 }
 
-/**
- * @runTestsInSeparateProcesses
- */
+
 class SpyTest extends PHPUnit_Framework_TestCase {
+	public function tearDown() {
+		\Spies\finish_spying();
+	}
+
 	public function test_spy_was_called_returns_true_if_called() {
 		$spy = new \Spies\Spy();
 		$spy();
Index: tests/MockObjectTest.php
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/tests/MockObjectTest.php b/tests/MockObjectTest.php
--- a/tests/MockObjectTest.php	
+++ b/tests/MockObjectTest.php	
@@ -14,10 +14,12 @@
 	}
 }
 
-/**
- * @runTestsInSeparateProcesses
- */
+
 class MockObjectTest extends PHPUnit_Framework_TestCase {
+	public function tearDown() {
+		\Spies\finish_spying();
+	}
+
 	public function test_mock_object_returns_mock_object() {
 		$mock = \Spies\mock_object();
 		$this->assertTrue( $mock instanceof \Spies\MockObject );

  ```
</details>

- on `master`, comment out `self::$global_functions = [];` in `src/Spies/GlobalSpies.php` (one liner change from https://github.com/sirbrillig/spies/pull/28)  run the tests; some tests fail, so there could be come problems with `finish_spying` (indicates the problem that PR tries to fix)
- on `master`, revert the one liner change and run tests again: tests get memory limit error, so the infinite loop is possibly introduced (indicates the problem this PR is trying to fix)
- checkout first commit of this branch, run the tests: no changes, so both issues remain but there is test for first issue now
- checkout second commit of this branch, run the tests: no changes, so both issues remain but there is test for both issues now
- checkout third commit of this branch, run the tests: tests pass, so both issues should be resolved by now