### PR TITLE
Fix(ArgumentFormatter): Fix TypeError thrown in PHP 8+ when method_exists is called on an array

### DIFF
--- a/src/Spies/ArgumentFormatter.php
+++ b/src/Spies/ArgumentFormatter.php
@@ -17,6 +17,9 @@ class ArgumentFormatter {
 
 	private function get_args_as_array() {
 		$stringify_argument = function ( $argument ) {
+			if(is_array($argument)) {
+				return json_encode($argument);
+			}
 			if ( method_exists( $argument, '__toString' ) ) {
 				return $argument->__toString();
 			}

--- a/tests/ArgumentFormatterTest.php
+++ b/tests/ArgumentFormatterTest.php
@@ -1,0 +1,35 @@
+<?php
+
+class ArgumentFormatterTest extends PHPUnit_Framework_TestCase {
+	public function tearDown() {
+		\Spies\finish_spying();
+	}
+
+	public function test__expect_to_string_returns_no_arguments_when_no_arguments_provided() {
+		$formatter = new \Spies\ArgumentFormatter( [] );
+		$this->assertEquals( 'no arguments', (string) $formatter );
+	}
+
+	public function test__expect_to_string_calls_to_string_from_arg_when_available() {
+		$argument = $this->getMockBuilder( 'stdClass' )
+			->setMethods( [ '__toString' ] )
+			->getMock();
+
+		$argument->expects( $this->once() )
+			->method( '__toString' )
+			->willReturn( 'stringified argument' );
+
+		$formatter = new \Spies\ArgumentFormatter( [ $argument ] );
+		$this->assertEquals( 'arguments: ( stringified argument )', (string) $formatter );
+	}
+
+	public function test__expect_to_string_returns_stringified_array_when_arg_is_array() {
+		$formatter = new \Spies\ArgumentFormatter( [ [ 'foo' => 'bar' ] ] );
+		$this->assertEquals( 'arguments: ( {"foo":"bar"} )', (string) $formatter );
+	}
+
+	public function test__expect_to_string_returns_string_when_arg_is_string() {
+		$formatter = new \Spies\ArgumentFormatter( [ 'foo' ] );
+		$this->assertEquals( 'arguments: ( "foo" )', (string) $formatter );
+	}
+}


### PR DESCRIPTION
In PHP 8.0+, `method_exists` throws a `TypeError` when an array is passed in. (More info: https://php.watch/versions/8.0/internal-function-exceptions).

This means that for a test like this:
```php
$spy = get_spy_for('my_function_that_the_component_class_uses_internally');       
$component = create_component_with_bg_color(['backgroundColors' => ['light', 'dark']]);

expect_spy($spy)->to_have_been_called->with(match_array(['light', 'accent']))->verify();
```

the TypeError is thrown when the assertion does not match.

## Current behaviour

If the assertion does not match, the test fails with:
> TypeError: method_exists(): Argument #1 ($object_or_class) must be of type object|string, array given

If the assertion does match, the test is ignored and the log shows:
> This test did not perform any assertions

## Expected behaviour 

If the assertion does not match, the test should fail with:
> Spies\UnmetExpectationException: Failed asserting that a spy is called with arguments: ( MatchArray(["light","accent"]) ).

If the assertion does match, the test should pass.

## Fix

Add an `is_array()` check and return a stringified array using `json_encode` before attempting to call `method_exists`.